### PR TITLE
Support detect Azure Event Hubs, connect by connection string.

### DIFF
--- a/cli/azd/resources/scaffold/base/modules/set-event-hubs-namespace-connection-string.bicep
+++ b/cli/azd/resources/scaffold/base/modules/set-event-hubs-namespace-connection-string.bicep
@@ -14,7 +14,6 @@ resource connectionStringSecret 'Microsoft.KeyVault/vaults/secrets@2022-07-01' =
   name: connectionStringSecretName
   parent: keyVault
   properties: {
-    value: listKeys(concat(resourceId('Microsoft.EventHub/namespaces', eventHubsNamespaceName), '/AuthorizationRules/RootManageSharedAccessKey'), '2024-01-01').primaryConnectionString
+    value: listKeys(concat(resourceId('Microsoft.EventHub/namespaces', eventHubsNamespaceName), '/AuthorizationRules/RootManageSharedAccessKey'), eventHubsNamespace.apiVersion).primaryConnectionString
   }
 }
-

--- a/cli/azd/resources/scaffold/base/modules/set-servicebus-namespace-connection-string.bicep
+++ b/cli/azd/resources/scaffold/base/modules/set-servicebus-namespace-connection-string.bicep
@@ -17,4 +17,3 @@ resource serviceBusConnectionStringSecret 'Microsoft.KeyVault/vaults/secrets@202
     value: listKeys(concat(resourceId('Microsoft.ServiceBus/namespaces', serviceBusNamespaceName), '/AuthorizationRules/RootManageSharedAccessKey'), serviceBusNamespace.apiVersion).primaryConnectionString
   }
 }
-

--- a/cli/azd/resources/scaffold/base/modules/set-storage-account-connection-string.bicep
+++ b/cli/azd/resources/scaffold/base/modules/set-storage-account-connection-string.bicep
@@ -1,0 +1,19 @@
+param storageAccountName string
+param connectionStringSecretName string
+param keyVaultName string
+
+resource storageAccount 'Microsoft.Storage/storageAccounts@2023-05-01' existing = {
+  name: storageAccountName
+}
+
+resource keyVault 'Microsoft.KeyVault/vaults@2022-07-01' existing = {
+  name: keyVaultName
+}
+
+resource connectionStringSecret 'Microsoft.KeyVault/vaults/secrets@2022-07-01' = {
+  name: connectionStringSecretName
+  parent: keyVault
+  properties: {
+    value: 'DefaultEndpointsProtocol=https;AccountName=${storageAccount.name};AccountKey=${storageAccount.listKeys().keys[0].value};EndpointSuffix=${environment().suffixes.storage}'
+  }
+}

--- a/cli/azd/resources/scaffold/templates/resources.bicept
+++ b/cli/azd/resources/scaffold/templates/resources.bicept
@@ -443,7 +443,7 @@ module {{bicepName .Name}} 'br/public:avm/res/app/container-app:0.8.0' = {
           {{- end}}
           {{- if (and .AzureEventHubs .AzureEventHubs.AuthUsingManagedIdentity) }}
           {
-            name: 'SPRING_CLOUD_AZURE_EVENTHUBS_CONNECTION_STRING'
+            name: 'SPRING_CLOUD_AZURE_EVENTHUBS_CONNECTIONSTRING'
             value: ''
           }
           {
@@ -457,7 +457,7 @@ module {{bicepName .Name}} 'br/public:avm/res/app/container-app:0.8.0' = {
           {{- end}}
           {{- if (and .AzureEventHubs .AzureEventHubs.AuthUsingConnectionString) }}
           {
-            name: 'SPRING_CLOUD_AZURE_EVENTHUBS_CONNECTION_STRING'
+            name: 'SPRING_CLOUD_AZURE_EVENTHUBS_CONNECTIONSTRING'
             secretRef: 'event-hubs-connection-string'
           }
           {
@@ -477,25 +477,29 @@ module {{bicepName .Name}} 'br/public:avm/res/app/container-app:0.8.0' = {
           {{- end}}
           {{- if (and .AzureStorageAccount .AzureStorageAccount.AuthUsingManagedIdentity) }}
           {
-            name: 'SPRING_CLOUD_AZURE_STORAGE_CREDENTIAL_MANAGEDIDENTITYENABLED'
+            name: 'SPRING_CLOUD_AZURE_EVENTHUBS_PROCESSOR_CHECKPOINTSTORE_CONNECTIONSTRING'
+            value: ''
+          }
+          {
+            name: 'SPRING_CLOUD_AZURE_EVENTHUBS_PROCESSOR_CHECKPOINTSTORE_CREDENTIAL_MANAGEDIDENTITYENABLED'
             value: 'true'
           }
           {
-            name: 'SPRING_CLOUD_AZURE_STORAGE_CREDENTIAL_CLIENTID'
+            name: 'SPRING_CLOUD_AZURE_EVENTHUBS_PROCESSOR_CHECKPOINTSTORE_CREDENTIAL_CLIENTID'
             value: {{bicepName .Name}}Identity.outputs.clientId
           }
           {{- end}}
           {{- if (and .AzureStorageAccount .AzureStorageAccount.AuthUsingConnectionString) }}
           {
-            name: 'SPRING_CLOUD_AZURE_STORAGE_CONNECTION_STRING'
+            name: 'SPRING_CLOUD_AZURE_EVENTHUBS_PROCESSOR_CHECKPOINTSTORE_CONNECTIONSTRING'
             secretRef: 'storage-account-connection-string'
           }
           {
-            name: 'SPRING_CLOUD_AZURE_STORAGE_CREDENTIAL_MANAGEDIDENTITYENABLED'
+            name: 'SPRING_CLOUD_AZURE_EVENTHUBS_PROCESSOR_CHECKPOINTSTORE_CREDENTIAL_MANAGEDIDENTITYENABLED'
             value: 'false'
           }
           {
-            name: 'SPRING_CLOUD_AZURE_STORAGE_CREDENTIAL_CLIENTID'
+            name: 'SPRING_CLOUD_AZURE_EVENTHUBS_PROCESSOR_CHECKPOINTSTORE_CREDENTIAL_CLIENTID'
             value: ''
           }
           {{- end}}
@@ -508,7 +512,7 @@ module {{bicepName .Name}} 'br/public:avm/res/app/container-app:0.8.0' = {
           {{- end}}
           {{- if (and .AzureServiceBus .AzureServiceBus.AuthUsingManagedIdentity) }}
           {
-            name: 'SPRING_CLOUD_AZURE_SERVICEBUS_CONNECTION_STRING'
+            name: 'SPRING_CLOUD_AZURE_SERVICEBUS_CONNECTIONSTRING'
             value: ''
           }
           {
@@ -522,7 +526,7 @@ module {{bicepName .Name}} 'br/public:avm/res/app/container-app:0.8.0' = {
           {{- end}}
           {{- if (and .AzureServiceBus .AzureServiceBus.AuthUsingConnectionString) }}
           {
-            name: 'SPRING_CLOUD_AZURE_SERVICEBUS_CONNECTION_STRING'
+            name: 'SPRING_CLOUD_AZURE_SERVICEBUS_CONNECTIONSTRING'
             secretRef: 'servicebus-connection-string'
           }
           {

--- a/cli/azd/resources/scaffold/templates/resources.bicept
+++ b/cli/azd/resources/scaffold/templates/resources.bicept
@@ -197,10 +197,21 @@ module storageAccount 'br/public:avm/res/storage/storage-account:0.14.3' = {
     ]
     networkAcls: {
       defaultAction: 'Allow'
-  }
+    }
     tags: tags
   }
 }
+
+{{- if (and .AzureStorageAccount .AzureStorageAccount.AuthUsingConnectionString) }}
+module storageAccountConnectionString './modules/set-storage-account-connection-string.bicep' = {
+  name: 'storageAccountConnectionString'
+  params: {
+    storageAccountName: storageAccountName
+    connectionStringSecretName: 'STORAGE-ACCOUNT-CONNECTION-STRING'
+    keyVaultName: keyVault.outputs.name
+  }
+}
+{{end}}
 {{end}}
 
 {{- if .AzureServiceBus }}
@@ -340,6 +351,13 @@ module {{bicepName .Name}} 'br/public:avm/res/app/container-app:0.8.0' = {
           keyVaultUrl: '${keyVault.outputs.uri}secrets/SERVICEBUS-CONNECTION-STRING'
         }
         {{- end}}
+        {{- if (and .AzureStorageAccount .AzureStorageAccount.AuthUsingConnectionString) }}
+        {
+          name: 'storage-account-connection-string'
+          identity:{{bicepName .Name}}Identity.outputs.resourceId
+          keyVaultUrl: '${keyVault.outputs.uri}secrets/STORAGE-ACCOUNT-CONNECTION-STRING'
+        }
+        {{- end}}
       ],
       map({{bicepName .Name}}Secrets, secret => {
         name: secret.secretRef
@@ -465,6 +483,20 @@ module {{bicepName .Name}} 'br/public:avm/res/app/container-app:0.8.0' = {
           {
             name: 'SPRING_CLOUD_AZURE_STORAGE_CREDENTIAL_CLIENTID'
             value: {{bicepName .Name}}Identity.outputs.clientId
+          }
+          {{- end}}
+          {{- if (and .AzureStorageAccount .AzureStorageAccount.AuthUsingConnectionString) }}
+          {
+            name: 'SPRING_CLOUD_AZURE_STORAGE_CONNECTION_STRING'
+            secretRef: 'storage-account-connection-string'
+          }
+          {
+            name: 'SPRING_CLOUD_AZURE_STORAGE_CREDENTIAL_MANAGEDIDENTITYENABLED'
+            value: 'false'
+          }
+          {
+            name: 'SPRING_CLOUD_AZURE_STORAGE_CREDENTIAL_CLIENTID'
+            value: ''
           }
           {{- end}}
 


### PR DESCRIPTION
Follow up of https://github.com/azure-javaee/azure-dev/pull/6

Support detect Azure Event Hubs

 - [x] Produce message only. [Link to sample project](https://github.com/rujche/samples/tree/azd-enhancement-for-spring-cloud-azure-stream-binder-eventhubs-supply-out-only-both-managed-identity-and-connection-string).
   - [x] Auth using user-assigned managed identity.
   - [x] Auth using connection string.
 - [x] Produce and consume message. [Link to sample project](https://github.com/rujche/samples/tree/azd-enhancement-for-spring-cloud-azure-stream-binder-eventhubs-both-consume-in-and-supply-out-both-managed-identity-and-connection-string)
   - [x] Auth using user-assigned managed identity.
   - [x] Auth using connection string.