### PR TITLE
Update azure.yaml schema reference for private preview

### DIFF
--- a/cli/azd/pkg/project/project.go
+++ b/cli/azd/pkg/project/project.go
@@ -23,7 +23,8 @@ import (
 
 const (
 	//nolint:lll
-	projectSchemaAnnotation = "# yaml-language-server: $schema=https://raw.githubusercontent.com/Azure/azure-dev/main/schemas/v1.0/azure.yaml.json"
+	// todo(haozhan): update this line for sjad private preview, need to revert it when merge into azure-dev/main branch
+	projectSchemaAnnotation = "# yaml-language-server: $schema=https://raw.githubusercontent.com/azure-javaee/azure-dev/feature/sjad/schemas/alpha/azure.yaml.json"
 )
 
 func New(ctx context.Context, projectFilePath string, projectName string) (*ProjectConfig, error) {

--- a/schemas/alpha/azure.yaml.json
+++ b/schemas/alpha/azure.yaml.json
@@ -352,6 +352,63 @@
                 ]
             }
         },
+        "resources": {
+            "type": "object",
+            "title": "Definition of resources that the application depends on",
+            "description": "Optional. Provides additional configuration for Azure resources that the application depends on.",
+            "minProperties": 1,
+            "additionalProperties": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                    "type"
+                ],
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "title": "Required. The type of Azure resource that the application depends on",
+                        "description": "The Azure resource type that the application depends on",
+                        "enum": [
+                            "db.mysql",
+                            "db.redis",
+                            "db.postgres",
+                            "db.mongo"
+                        ]
+                    },
+                    "authType": {
+                        "type": "string",
+                        "title": "The authentication type of Azure resource used for the application",
+                        "description": "The application uses this kind of authentication to connect to the Azure resource.",
+                        "enum": [
+                            "managedIdentity",
+                            "usernamePassword"
+                        ]
+                    },
+                    "databaseName": {
+                        "type": "string",
+                        "title": "The name of Azure resource that the application depends on",
+                        "description": "The Azure resource that will be accessed during application runtime."
+                    }
+                },
+                "allOf": [
+                    {
+                        "if": {
+                            "properties": {
+                                "type": {
+                                    "const": "db.mysql"
+                                }
+                            }
+                        },
+                        "then": {
+                            "required": [
+                                "authType",
+                                "databaseName"
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
         "pipeline": {
             "type": "object",
             "title": "Definition of continuous integration pipeline",


### PR DESCRIPTION
+ When azd init, the generated `azure.yaml` file refers to the latest schema in the `feature/sjad` branch.
+ Just for private preview, need to revert it when merge into `azd-dev/main` branch.