### PR TITLE
Inject AzureEventHubsKafkaAutoConfiguration package path based on spring boot version

### DIFF
--- a/cli/azd/internal/appdetect/appdetect.go
+++ b/cli/azd/internal/appdetect/appdetect.go
@@ -150,8 +150,9 @@ func (a AzureDepServiceBus) ResourceDisplay() string {
 }
 
 type AzureDepEventHubs struct {
-	Names    []string
-	UseKafka bool
+	Names             []string
+	UseKafka          bool
+	SpringBootVersion string
 }
 
 func (a AzureDepEventHubs) ResourceDisplay() string {
@@ -172,6 +173,8 @@ type SpringCloudAzureDep struct {
 func (a SpringCloudAzureDep) ResourceDisplay() string {
 	return "Spring Cloud Azure Starter"
 }
+
+const UnknownSpringBootVersion string = "unknownSpringBootVersion"
 
 type Project struct {
 	// The language associated with the project.

--- a/cli/azd/internal/appdetect/java.go
+++ b/cli/azd/internal/appdetect/java.go
@@ -74,6 +74,7 @@ type mavenProject struct {
 	XmlName              xml.Name             `xml:"project"`
 	Parent               parent               `xml:"parent"`
 	Modules              []string             `xml:"modules>module"` // Capture the modules
+	Properties           Properties           `xml:"properties"`
 	Dependencies         []dependency         `xml:"dependencies>dependency"`
 	DependencyManagement dependencyManagement `xml:"dependencyManagement"`
 	Build                build                `xml:"build"`
@@ -85,6 +86,15 @@ type parent struct {
 	GroupId    string `xml:"groupId"`
 	ArtifactId string `xml:"artifactId"`
 	Version    string `xml:"version"`
+}
+
+type Properties struct {
+	Entries []Property `xml:",any"` // Capture all elements inside <properties>
+}
+
+type Property struct {
+	XMLName xml.Name
+	Value   string `xml:",chardata"`
 }
 
 // Dependency represents a single Maven dependency.
@@ -385,6 +395,14 @@ func contains(array []string, str string) bool {
 	return false
 }
 
+func parseProperties(properties Properties) map[string]string {
+	result := make(map[string]string)
+	for _, entry := range properties.Entries {
+		result[entry.XMLName.Local] = entry.Value
+	}
+	return result
+}
+
 func detectSpringBootVersion(currentRoot *mavenProject, mavenProject *mavenProject) string {
 	if currentRoot != nil {
 		return detectSpringBootVersionFromProject(currentRoot)
@@ -396,13 +414,21 @@ func detectSpringBootVersion(currentRoot *mavenProject, mavenProject *mavenProje
 
 func detectSpringBootVersionFromProject(project *mavenProject) string {
 	if project.Parent.ArtifactId == "spring-boot-starter-parent" {
-		return project.Parent.Version
+		return depVersion(project.Parent.Version, project.Properties)
 	} else {
 		for _, dep := range project.DependencyManagement.Dependencies {
 			if dep.ArtifactId == "spring-boot-dependencies" {
-				return dep.Version
+				return depVersion(dep.Version, project.Properties)
 			}
 		}
 	}
 	return UnknownSpringBootVersion
+}
+
+func depVersion(version string, properties Properties) string {
+	if strings.HasPrefix(version, "${") {
+		return parseProperties(properties)[version[2:len(version)-1]]
+	} else {
+		return version
+	}
 }

--- a/cli/azd/internal/appdetect/java_test.go
+++ b/cli/azd/internal/appdetect/java_test.go
@@ -1,6 +1,7 @@
 package appdetect
 
 import (
+	"encoding/xml"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
@@ -47,6 +48,32 @@ func TestDetectSpringBootVersion(t *testing.T) {
 			"2.x",
 		},
 		{
+			"project.dependencyManagement",
+			nil,
+			&mavenProject{
+				Properties: Properties{
+					Entries: []Property{
+						{
+							XMLName: xml.Name{
+								Local: "version.spring.boot",
+							},
+							Value: "2.x",
+						},
+					},
+				},
+				DependencyManagement: dependencyManagement{
+					Dependencies: []dependency{
+						{
+							GroupId:    "org.springframework.boot",
+							ArtifactId: "spring-boot-dependencies",
+							Version:    "${version.spring.boot}",
+						},
+					},
+				},
+			},
+			"2.x",
+		},
+		{
 			"root.parent",
 			&mavenProject{
 				Parent: parent{
@@ -72,6 +99,32 @@ func TestDetectSpringBootVersion(t *testing.T) {
 				},
 			},
 			nil,
+			"3.x",
+		},
+		{
+			"root.dependencyManagement",
+			nil,
+			&mavenProject{
+				Properties: Properties{
+					Entries: []Property{
+						{
+							XMLName: xml.Name{
+								Local: "version.spring.boot",
+							},
+							Value: "3.x",
+						},
+					},
+				},
+				DependencyManagement: dependencyManagement{
+					Dependencies: []dependency{
+						{
+							GroupId:    "org.springframework.boot",
+							ArtifactId: "spring-boot-dependencies",
+							Version:    "${version.spring.boot}",
+						},
+					},
+				},
+			},
 			"3.x",
 		},
 	}

--- a/cli/azd/internal/appdetect/java_test.go
+++ b/cli/azd/internal/appdetect/java_test.go
@@ -1,0 +1,84 @@
+package appdetect
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestDetectSpringBootVersion(t *testing.T) {
+	tests := []struct {
+		name            string
+		currentRoot     *mavenProject
+		project         *mavenProject
+		expectedVersion string
+	}{
+		{
+			"unknown",
+			nil,
+			nil,
+			UnknownSpringBootVersion,
+		},
+		{
+			"project.parent",
+			nil,
+			&mavenProject{
+				Parent: parent{
+					GroupId:    "org.springframework.boot",
+					ArtifactId: "spring-boot-starter-parent",
+					Version:    "2.x",
+				},
+			},
+			"2.x",
+		},
+		{
+			"project.dependencyManagement",
+			nil,
+			&mavenProject{
+				DependencyManagement: dependencyManagement{
+					Dependencies: []dependency{
+						{
+							GroupId:    "org.springframework.boot",
+							ArtifactId: "spring-boot-dependencies",
+							Version:    "2.x",
+						},
+					},
+				},
+			},
+			"2.x",
+		},
+		{
+			"root.parent",
+			&mavenProject{
+				Parent: parent{
+					GroupId:    "org.springframework.boot",
+					ArtifactId: "spring-boot-starter-parent",
+					Version:    "3.x",
+				},
+			},
+			nil,
+			"3.x",
+		},
+		{
+			"root.dependencyManagement",
+			&mavenProject{
+				DependencyManagement: dependencyManagement{
+					Dependencies: []dependency{
+						{
+							GroupId:    "org.springframework.boot",
+							ArtifactId: "spring-boot-dependencies",
+							Version:    "3.x",
+						},
+					},
+				},
+			},
+			nil,
+			"3.x",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			version := detectSpringBootVersion(tt.currentRoot, tt.project)
+			assert.Equal(t, tt.expectedVersion, version)
+		})
+	}
+}

--- a/cli/azd/internal/repository/app_init.go
+++ b/cli/azd/internal/repository/app_init.go
@@ -137,11 +137,23 @@ func (i *Initializer) InitFromApp(
 		if prj.Language == appdetect.Java {
 			var hasKafkaDep bool
 			var hasSpringCloudAzureDep bool
-			for _, dep := range prj.AzureDeps {
-				if eventHubs, ok := dep.(appdetect.AzureDepEventHubs); ok && eventHubs.UseKafka {
+			for depIndex := range prj.AzureDeps {
+				dep := &prj.AzureDeps[depIndex]
+				if eventHubs, ok := (*dep).(appdetect.AzureDepEventHubs); ok && eventHubs.UseKafka {
 					hasKafkaDep = true
+					springBootVersion := eventHubs.SpringBootVersion
+
+					if springBootVersion == appdetect.UnknownSpringBootVersion {
+						var err error
+						springBootVersion, err = promptSpringBootVersion(i.console, ctx)
+						if err != nil {
+							return err
+						}
+						eventHubs.SpringBootVersion = springBootVersion
+						prj.AzureDeps[depIndex] = eventHubs
+					}
 				}
-				if _, ok := dep.(appdetect.SpringCloudAzureDep); ok {
+				if _, ok := (*dep).(appdetect.SpringCloudAzureDep); ok {
 					hasSpringCloudAzureDep = true
 				}
 			}
@@ -820,4 +832,26 @@ func processSpringCloudAzureDepByPrompt(console input.Console, ctx context.Conte
 		return nil
 	}
 	return nil
+}
+
+func promptSpringBootVersion(console input.Console, ctx context.Context) (string, error) {
+	selection, err := console.Select(ctx, input.ConsoleOptions{
+		Message: "No spring boot version detected, what is your spring boot version?",
+		Options: []string{
+			"Spring Boot 2.x",
+			"Spring Boot 3.x",
+		},
+	})
+	if err != nil {
+		return "", err
+	}
+
+	switch selection {
+	case 0:
+		return "2.x", nil
+	case 1:
+		return "3.x", nil
+	default:
+		panic("unhandled selection")
+	}
 }

--- a/cli/azd/internal/repository/infra_confirm.go
+++ b/cli/azd/internal/repository/infra_confirm.go
@@ -349,9 +349,10 @@ func (i *Initializer) buildInfraSpecByAzureDep(
 		}
 	case appdetect.AzureDepEventHubs:
 		spec.AzureEventHubs = &scaffold.AzureDepEventHubs{
-			EventHubNames: dependency.Names,
-			AuthType:      authType,
-			UseKafka:      dependency.UseKafka,
+			EventHubNames:     dependency.Names,
+			AuthType:          authType,
+			UseKafka:          dependency.UseKafka,
+			SpringBootVersion: dependency.SpringBootVersion,
 		}
 	case appdetect.AzureDepStorageAccount:
 		spec.AzureStorageAccount = &scaffold.AzureDepStorageAccount{

--- a/cli/azd/internal/scaffold/scaffold.go
+++ b/cli/azd/internal/scaffold/scaffold.go
@@ -30,6 +30,7 @@ func Load() (*template.Template, error) {
 		"lower":            strings.ToLower,
 		"alphaSnakeUpper":  AlphaSnakeUpper,
 		"formatParam":      FormatParameter,
+		"hasPrefix":        strings.HasPrefix,
 	}
 
 	t, err := template.New("templates").

--- a/cli/azd/internal/scaffold/spec.go
+++ b/cli/azd/internal/scaffold/spec.go
@@ -83,9 +83,10 @@ type AzureDepServiceBus struct {
 }
 
 type AzureDepEventHubs struct {
-	EventHubNames []string
-	AuthType      internal.AuthType
-	UseKafka      bool
+	EventHubNames     []string
+	AuthType          internal.AuthType
+	UseKafka          bool
+	SpringBootVersion string
 }
 
 type AzureDepStorageAccount struct {

--- a/cli/azd/resources/scaffold/templates/resources.bicept
+++ b/cli/azd/resources/scaffold/templates/resources.bicept
@@ -788,6 +788,18 @@ module {{bicepName .Name}} 'br/public:avm/res/app/container-app:0.8.0' = {
             name: 'spring.cloud.stream.kafka.binder.brokers'
             value: '${eventHubNamespace.outputs.name}.servicebus.windows.net:9093'
           }
+          {{- if (hasPrefix .AzureEventHubs.SpringBootVersion "2.") }}
+          {
+            name: 'spring.cloud.stream.binders.kafka.environment.spring.main.sources'
+            value: 'com.azure.spring.cloud.autoconfigure.eventhubs.kafka.AzureEventHubsKafkaAutoConfiguration'
+          }
+          {{- end}}
+          {{- if (hasPrefix .AzureEventHubs.SpringBootVersion "3.") }}
+          {
+            name: 'spring.cloud.stream.binders.kafka.environment.spring.main.sources'
+            value: 'com.azure.spring.cloud.autoconfigure.implementation.eventhubs.kafka.AzureEventHubsKafkaAutoConfiguration'
+          }
+          {{- end}}
           {{- end}}
           {{- if (and .AzureEventHubs (eq .AzureEventHubs.AuthType "USER_ASSIGNED_MANAGED_IDENTITY")) }}
           {


### PR DESCRIPTION
Inject AzureEventHubsKafkaAutoConfiguration package path based on spring boot version, by following the example: 
+ for connection string auth, https://github.com/Azure-Samples/azure-spring-boot-samples/blob/41d72a3d3c6d406f440f66c4b19813f8624096cd/eventhubs/spring-cloud-azure-starter/spring-cloud-azure-sample-eventhubs-kafka/src/main/resources/application.yaml#L15C1-L23C130
+ for MI auth:  https://learn.microsoft.com/en-us/azure/developer/java/spring-framework/kafka-support?tabs=SpringCloudAzure4x#configuration-1