### PR TITLE
Fix code to support service bus jms in azd composability

### DIFF
--- a/cli/azd/internal/repository/app_init.go
+++ b/cli/azd/internal/repository/app_init.go
@@ -658,6 +658,17 @@ func (i *Initializer) prjConfigFromDetect(
 				resSpec.Uses = append(resSpec.Uses, dbNames[db])
 			}
 
+			for _, azureDep := range svc.AzureDeps {
+				switch azureDep.(type) {
+				case appdetect.AzureDepServiceBus:
+					resSpec.Uses = append(resSpec.Uses, "servicebus")
+				case appdetect.AzureDepEventHubs:
+					resSpec.Uses = append(resSpec.Uses, "eventhubs")
+				case appdetect.AzureDepStorageAccount:
+					resSpec.Uses = append(resSpec.Uses, "storage")
+				}
+			}
+
 			resSpec.Name = name
 			resSpec.Props = props
 			config.Resources[name] = &resSpec

--- a/cli/azd/internal/scaffold/scaffold.go
+++ b/cli/azd/internal/scaffold/scaffold.go
@@ -3,6 +3,7 @@ package scaffold
 import (
 	"bytes"
 	"fmt"
+	"github.com/azure/azure-dev/cli/azd/internal"
 	"io/fs"
 	"os"
 	"path"
@@ -74,6 +75,18 @@ func supportingFiles(spec InfraSpec) []string {
 
 	if len(spec.Services) > 0 {
 		files = append(files, "/modules/fetch-container-image.bicep")
+	}
+
+	if spec.AzureServiceBus != nil && spec.AzureServiceBus.AuthType == internal.AuthTypeConnectionString {
+		files = append(files, "/modules/set-servicebus-namespace-connection-string.bicep")
+	}
+
+	if spec.AzureEventHubs != nil && spec.AzureEventHubs.AuthType == internal.AuthTypeConnectionString {
+		files = append(files, "/modules/set-event-hubs-namespace-connection-string.bicep")
+	}
+
+	if spec.AzureStorageAccount != nil && spec.AzureStorageAccount.AuthType == internal.AuthTypeConnectionString {
+		files = append(files, "/modules/set-storage-account-connection-string.bicep")
 	}
 
 	return files

--- a/cli/azd/pkg/project/scaffold_gen.go
+++ b/cli/azd/pkg/project/scaffold_gen.go
@@ -339,6 +339,13 @@ func mapHostUses(
 			backendMapping[use] = res.Name // record the backend -> frontend mapping
 		case ResourceTypeOpenAiModel:
 			svcSpec.AIModels = append(svcSpec.AIModels, scaffold.AIModelReference{Name: use})
+		case ResourceTypeMessagingServiceBus:
+			props := useRes.Props.(ServiceBusProps)
+			svcSpec.AzureServiceBus = &scaffold.AzureDepServiceBus{
+				Queues:   props.Queues,
+				AuthType: props.AuthType,
+				IsJms:    props.IsJms,
+			}
 		}
 	}
 


### PR DESCRIPTION
This PR will fix the servicebus jms support when `azd composability` is enabled. To enable `azd composability`, run `azd config set alpha.compose on`