### PR TITLE
Users can continue to use azd when java analyzer fails

### DIFF
--- a/cli/azd/internal/appdetect/java.go
+++ b/cli/azd/internal/appdetect/java.go
@@ -33,7 +33,9 @@ func (jd *javaDetector) DetectProject(ctx context.Context, path string, entries 
 			pomFile := filepath.Join(path, entry.Name())
 			project, err := readMavenProject(pomFile)
 			if err != nil {
-				return nil, fmt.Errorf("error reading pom.xml: %w", err)
+				log.Printf("Please edit azure.yaml manually to satisfy your requirement. azd can not help you "+
+					"to that by detect your java project because error happened when reading pom.xml: %s. ", err)
+				return nil, nil
 			}
 
 			if len(project.Modules) > 0 {
@@ -58,7 +60,9 @@ func (jd *javaDetector) DetectProject(ctx context.Context, path string, entries 
 				DetectionRule: "Inferred by presence of: pom.xml",
 			})
 			if err != nil {
-				return nil, fmt.Errorf("detecting dependencies: %w", err)
+				log.Printf("Please edit azure.yaml manually to satisfy your requirement. azd can not help you "+
+					"to that by detect your java project because error happened when detecting dependencies: %s", err)
+				return nil, nil
 			}
 
 			tracing.SetUsageAttributes(fields.AppInitJavaDetect.String("finish"))

--- a/cli/azd/internal/auth_type.go
+++ b/cli/azd/internal/auth_type.go
@@ -23,6 +23,7 @@ func GetAuthTypeDescription(authType AuthType) string {
 		return "Connection string"
 	case AuthTypeUserAssignedManagedIdentity:
 		return "User assigned managed identity"
+	default:
+		return "Unspecified"
 	}
-	panic("unknown auth type")
 }

--- a/cli/azd/internal/repository/app_init.go
+++ b/cli/azd/internal/repository/app_init.go
@@ -875,6 +875,6 @@ func promptSpringBootVersion(console input.Console, ctx context.Context) (string
 	case 1:
 		return "3.x", nil
 	default:
-		panic("unhandled selection")
+		return appdetect.UnknownSpringBootVersion, nil
 	}
 }


### PR DESCRIPTION
1. Delete all "panic" introduced in this PR: https://github.com/Azure/azure-dev/pull/4473/files
2. Not return error in `(jd *javaDetector) DetectProject`, and guide users to edit azure.yaml manually.