### PR TITLE
Fix bug: Deploy failed for the second time when resource name too long

### DIFF
--- a/cli/azd/resources/scaffold/templates/resources.bicept
+++ b/cli/azd/resources/scaffold/templates/resources.bicept
@@ -520,7 +520,7 @@ module {{bicepName .Name}}FetchLatestImage './modules/fetch-container-image.bice
   name: '{{bicepName .Name}}-fetch-image'
   params: {
     exists: {{bicepName .Name}}Exists
-    name: '{{.Name}}'
+    name: '{{containerAppName .Name}}'
   }
 }
 


### PR DESCRIPTION
Fix bug: Deploy failed for the second time when resource name too long.

Screenshot when the bug happens:

> ![image](https://github.com/user-attachments/assets/ad68b47f-0fc8-49dd-9925-39c28d520449)

> ![image](https://github.com/user-attachments/assets/8ccac568-e127-4f7a-8884-eb3e4545a553)
