### PR TITLE
Replace placeholders during parsing pom.xml

### DIFF
--- a/cli/azd/internal/appdetect/java.go
+++ b/cli/azd/internal/appdetect/java.go
@@ -10,6 +10,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 )
 
@@ -127,14 +128,44 @@ func readMavenProject(filePath string) (*mavenProject, error) {
 		return nil, err
 	}
 
+	var initialProject mavenProject
+	if err := xml.Unmarshal(bytes, &initialProject); err != nil {
+		return nil, fmt.Errorf("parsing xml: %w", err)
+	}
+
+	// replace all placeholders with properties
+	str := replaceAllPlaceholders(initialProject, string(bytes))
+
 	var project mavenProject
-	if err := xml.Unmarshal(bytes, &project); err != nil {
+	if err := xml.Unmarshal([]byte(str), &project); err != nil {
 		return nil, fmt.Errorf("parsing xml: %w", err)
 	}
 
 	project.path = filepath.Dir(filePath)
 
 	return &project, nil
+}
+
+func replaceAllPlaceholders(project mavenProject, input string) string {
+	propsMap := parseProperties(project.Properties)
+
+	re := regexp.MustCompile(`\$\{([A-Za-z0-9-_.]+)}`)
+	return re.ReplaceAllStringFunc(input, func(match string) string {
+		// Extract the key inside ${}
+		key := re.FindStringSubmatch(match)[1]
+		if value, exists := propsMap[key]; exists {
+			return value
+		}
+		return match
+	})
+}
+
+func parseProperties(properties Properties) map[string]string {
+	result := make(map[string]string)
+	for _, entry := range properties.Entries {
+		result[entry.XMLName.Local] = entry.Value
+	}
+	return result
 }
 
 func detectDependencies(currentRoot *mavenProject, mavenProject *mavenProject, project *Project) (*Project, error) {

--- a/cli/azd/internal/appdetect/spring_boot.go
+++ b/cli/azd/internal/appdetect/spring_boot.go
@@ -276,11 +276,11 @@ func detectSpringBootVersion(currentRoot *mavenProject, mavenProject *mavenProje
 
 func detectSpringBootVersionFromProject(project *mavenProject) string {
 	if project.Parent.ArtifactId == "spring-boot-starter-parent" {
-		return depVersion(project.Parent.Version, project.Properties)
+		return project.Parent.Version
 	} else {
 		for _, dep := range project.DependencyManagement.Dependencies {
 			if dep.ArtifactId == "spring-boot-dependencies" {
-				return depVersion(dep.Version, project.Properties)
+				return dep.Version
 			}
 		}
 	}
@@ -303,22 +303,6 @@ func isSpringBootApplication(mavenProject *mavenProject) bool {
 		}
 	}
 	return false
-}
-
-func depVersion(version string, properties Properties) string {
-	if strings.HasPrefix(version, "${") {
-		return parseProperties(properties)[version[2:len(version)-1]]
-	} else {
-		return version
-	}
-}
-
-func parseProperties(properties Properties) map[string]string {
-	result := make(map[string]string)
-	for _, entry := range properties.Entries {
-		result[entry.XMLName.Local] = entry.Value
-	}
-	return result
 }
 
 func distinctValues(input map[string]string) []string {


### PR DESCRIPTION
Replace placeholders during parsing pom.xml, to make it easy to analyze pom file later.