### PR TITLE
A few enhancements for deploy spring petclinic microservices

### DIFF
--- a/cli/azd/pkg/project/scaffold_gen_environment_variables.go
+++ b/cli/azd/pkg/project/scaffold_gen_environment_variables.go
@@ -578,8 +578,9 @@ func GetResourceConnectionEnvs(usedResource *ResourceConfig,
 	case ResourceTypeJavaConfigServer:
 		return []scaffold.Env{
 			{
-				Name:  "spring.config.import",
-				Value: fmt.Sprintf("optional:configserver:%s?fail-fast=true", scaffold.GetContainerAppHost(usedResource.Name)),
+				Name: "spring.config.import",
+				Value: fmt.Sprintf("optional:configserver:%s?fail-fast=true",
+					scaffold.GetContainerAppHost(usedResource.Name)),
 			},
 		}, nil
 	default:

--- a/cli/azd/pkg/project/scaffold_gen_environment_variables.go
+++ b/cli/azd/pkg/project/scaffold_gen_environment_variables.go
@@ -579,7 +579,7 @@ func GetResourceConnectionEnvs(usedResource *ResourceConfig,
 		return []scaffold.Env{
 			{
 				Name:  "spring.config.import",
-				Value: fmt.Sprintf("optional:configserver:%s", scaffold.GetContainerAppHost(usedResource.Name)),
+				Value: fmt.Sprintf("optional:configserver:%s?fail-fast=true", scaffold.GetContainerAppHost(usedResource.Name)),
 			},
 		}, nil
 	default:

--- a/cli/azd/resources/scaffold/templates/resources.bicept
+++ b/cli/azd/resources/scaffold/templates/resources.bicept
@@ -623,7 +623,7 @@ module {{bicepName .Name}} 'br/public:avm/res/app/container-app:0.8.0' = {
           {{- range $i, $e := .Frontend.Backends}}
           {
             name: '{{upper .Name}}_BASE_URL'
-            value: 'https://{{.Name}}.${containerAppsEnvironment.outputs.defaultDomain}'
+            value: 'https://${ {{bicepName .Name}}.outputs.name}.${containerAppsEnvironment.outputs.defaultDomain}'
           }
           {{- end}}
           {{- end}}
@@ -631,11 +631,15 @@ module {{bicepName .Name}} 'br/public:avm/res/app/container-app:0.8.0' = {
           {{- range $i, $e := .Backend.Frontends}}
           {
             name: '{{upper .Name}}_BASE_URL'
-            value: 'https://{{.Name}}.${containerAppsEnvironment.outputs.defaultDomain}'
+            value: 'https://{{containerAppName .Name}}.${containerAppsEnvironment.outputs.defaultDomain}'
           }
           {{- end}}
           {{- end}}
           {{- if ne .Port 0}}
+          {
+            name: 'server.port'
+            value: '{{ .Port }}'
+          }
           {
             name: 'PORT'
             value: '{{ .Port }}'


### PR DESCRIPTION
1. Set config client as `fail-fast=true`, to make it restart to reconcile if config server unavailable, until fetch from config server. This can avoid the application starts up without remote config server.
2. Add `server.port` Env to explicitly specify exposed port, because petclinic microservice will select random port in config server settings.
3. When a frontend app A has a call dependency on backend app B, it will add a Env `XXX_BASE_URL` to indicate it. Now I refer to the output of container app Bicep module, to make them topologized.