### PR TITLE
Delete password check when using managed identity as auth type

### DIFF
--- a/cli/azd/internal/appdetect/appdetect.go
+++ b/cli/azd/internal/appdetect/appdetect.go
@@ -187,7 +187,6 @@ type Metadata struct {
 	ContainsDependencySpringCloudAzureStarter               bool
 	ContainsDependencySpringCloudAzureStarterJdbcPostgresql bool
 	ContainsDependencySpringCloudAzureStarterJdbcMysql      bool
-	ContainsPropertySpringDatasourcePassword                bool
 }
 
 const UnknownSpringBootVersion string = "unknownSpringBootVersion"

--- a/cli/azd/internal/appdetect/spring_boot.go
+++ b/cli/azd/internal/appdetect/spring_boot.go
@@ -259,7 +259,6 @@ func detectMetadata(azdProject *Project, springBootProject *SpringBootProject) {
 	detectDependencySpringCloudAzureStarter(azdProject, springBootProject)
 	detectDependencySpringCloudAzureStarterJdbcPostgresql(azdProject, springBootProject)
 	detectDependencySpringCloudAzureStarterJdbcMysql(azdProject, springBootProject)
-	detectPropertySpringDatasourcePassword(azdProject, springBootProject)
 }
 
 func detectDependencySpringCloudAzureStarter(azdProject *Project, springBootProject *SpringBootProject) {
@@ -286,14 +285,6 @@ func detectDependencySpringCloudAzureStarterJdbcMysql(azdProject *Project, sprin
 	if hasDependency(springBootProject, targetGroupId, targetArtifactId) {
 		azdProject.Metadata.ContainsDependencySpringCloudAzureStarterJdbcMysql = true
 		logMetadataUpdated("ContainsDependencySpringCloudAzureStarterJdbcMysql = true")
-	}
-}
-
-func detectPropertySpringDatasourcePassword(azdProject *Project, springBootProject *SpringBootProject) {
-	var targetProperty = "spring.datasource.password"
-	if _, ok := springBootProject.applicationProperties[targetProperty]; ok {
-		azdProject.Metadata.ContainsPropertySpringDatasourcePassword = true
-		logMetadataUpdated("ContainsPropertySpringDatasourcePassword = true")
 	}
 }
 

--- a/cli/azd/internal/repository/app_init.go
+++ b/cli/azd/internal/repository/app_init.go
@@ -812,9 +812,7 @@ func checkPasswordlessConfigurationAndContinueProvision(database appdetect.Datab
 		return true, nil
 	}
 	for i, prj := range detect.Services {
-		if prj.Language == appdetect.Java &&
-			(!prj.Metadata.ContainsDependencySpringCloudAzureStarter ||
-				prj.Metadata.ContainsPropertySpringDatasourcePassword) {
+		if prj.Language == appdetect.Java && !prj.Metadata.ContainsDependencySpringCloudAzureStarter {
 			message := fmt.Sprintf("You selected %s as auth type for %s.",
 				internal.AuthTypeUserAssignedManagedIdentity, database)
 			if database == appdetect.DbPostgres && !prj.Metadata.ContainsDependencySpringCloudAzureStarterJdbcPostgresql {
@@ -826,11 +824,6 @@ func checkPasswordlessConfigurationAndContinueProvision(database appdetect.Datab
 				message = fmt.Sprintf("%s This dependency is required: "+
 					"'com.azure.spring:spring-cloud-azure-starter-jdbc-mysql'. "+
 					"But this dependency is not found in your project: %s.", message, prj.Path)
-			}
-			if prj.Metadata.ContainsPropertySpringDatasourcePassword {
-				message = fmt.Sprintf("%s This property should be deleted: "+
-					"'spring.datasource.password'. "+
-					"But this property is found in your project: %s.", message, prj.Path)
 			}
 			continueOption, err := console.Select(ctx, input.ConsoleOptions{
 				Message: fmt.Sprintf("%s Select an option:", message),


### PR DESCRIPTION
Delete password check when using managed identity as auth type. Because the configured password will be ignored without and error.