### PR TITLE
Fix error about auth type

### DIFF
--- a/cli/azd/pkg/project/scaffold_gen.go
+++ b/cli/azd/pkg/project/scaffold_gen.go
@@ -337,10 +337,10 @@ func getAuthType(infraSpec *scaffold.InfraSpec, resourceType ResourceType) (inte
 		return infraSpec.DbMySql.AuthType, nil
 	case ResourceTypeDbRedis:
 		return internal.AuthTypePassword, nil
-	case ResourceTypeDbMongo,
-		ResourceTypeDbCosmos,
-		ResourceTypeOpenAiModel,
-		ResourceTypeHostContainerApp:
+	case ResourceTypeDbMongo:
+		return internal.AuthTypeConnectionString, nil
+	case ResourceTypeDbCosmos,
+		ResourceTypeOpenAiModel:
 		return internal.AuthTypeUserAssignedManagedIdentity, nil
 	case ResourceTypeMessagingServiceBus:
 		return infraSpec.AzureServiceBus.AuthType, nil
@@ -349,7 +349,8 @@ func getAuthType(infraSpec *scaffold.InfraSpec, resourceType ResourceType) (inte
 	case ResourceTypeStorage:
 		return infraSpec.AzureStorageAccount.AuthType, nil
 	case ResourceTypeJavaEurekaServer,
-		ResourceTypeJavaConfigServer:
+		ResourceTypeJavaConfigServer,
+		ResourceTypeHostContainerApp:
 		return internal.AuthTypeUnspecified, nil
 	default:
 		return internal.AuthTypeUnspecified, fmt.Errorf("can not get authType, resource type: %s", resourceType)

--- a/cli/azd/pkg/project/scaffold_gen_environment_variables.go
+++ b/cli/azd/pkg/project/scaffold_gen_environment_variables.go
@@ -2,9 +2,10 @@ package project
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/azure/azure-dev/cli/azd/internal"
 	"github.com/azure/azure-dev/cli/azd/internal/scaffold"
-	"strings"
 )
 
 func GetResourceConnectionEnvs(usedResource *ResourceConfig,
@@ -235,7 +236,7 @@ func GetResourceConnectionEnvs(usedResource *ResourceConfig,
 		}
 	case ResourceTypeDbMongo:
 		switch authType {
-		case internal.AuthTypeUserAssignedManagedIdentity:
+		case internal.AuthTypeConnectionString:
 			return []scaffold.Env{
 				{
 					Name: "MONGODB_URL",
@@ -551,7 +552,7 @@ func GetResourceConnectionEnvs(usedResource *ResourceConfig,
 		}
 	case ResourceTypeHostContainerApp: // todo improve this and delete Frontend and Backend in scaffold.ServiceSpec
 		switch authType {
-		case internal.AuthTypeUserAssignedManagedIdentity:
+		case internal.AuthTypeUnspecified:
 			return []scaffold.Env{}, nil
 		default:
 			return []scaffold.Env{}, unsupportedAuthTypeError(resourceType, authType)


### PR DESCRIPTION
Fix error about auth type:
1. Mongo DB use connection string.
2. Container App's auth type is unspecified.