### PR TITLE
Fix: manually set empty password when using MI auth

### DIFF
--- a/cli/azd/pkg/project/scaffold_gen_environment_variables.go
+++ b/cli/azd/pkg/project/scaffold_gen_environment_variables.go
@@ -98,6 +98,10 @@ func GetResourceConnectionEnvs(usedResource *ResourceConfig,
 						scaffold.ResourceTypeDbPostgres, scaffold.ResourceInfoTypeUsername),
 				},
 				{
+					Name:  "spring.datasource.password",
+					Value: "",
+				},
+				{
 					Name:  "spring.datasource.azure.passwordless-enabled",
 					Value: "true",
 				},
@@ -186,6 +190,10 @@ func GetResourceConnectionEnvs(usedResource *ResourceConfig,
 					Name: "spring.datasource.username",
 					Value: scaffold.ToResourceConnectionEnv(
 						scaffold.ResourceTypeDbMySQL, scaffold.ResourceInfoTypeUsername),
+				},
+				{
+					Name:  "spring.datasource.password",
+					Value: "",
 				},
 				{
 					Name:  "spring.datasource.azure.passwordless-enabled",


### PR DESCRIPTION
when MI auth enabled (passwordless-enabled = true), we still need to manually set the password as empty. Otherwise, if source code set password, Jdbc will use password auth instead of MI auth.