### PR TITLE
Fix: manually set empty password when using MI auth

### DIFF
--- a/cli/azd/internal/scaffold/spec_service_binding.go
+++ b/cli/azd/internal/scaffold/spec_service_binding.go
@@ -264,6 +264,10 @@ func GetServiceBindingEnvsForPostgres(postgres DatabasePostgres) ([]Env, error) 
 				Value: ToServiceBindingEnvValue(ServiceTypeDbPostgres, ServiceBindingInfoTypeUsername),
 			},
 			{
+				Name:  "spring.datasource.password",
+				Value: "",
+			},
+			{
 				Name:  "spring.datasource.azure.passwordless-enabled",
 				Value: "true",
 			},
@@ -339,6 +343,10 @@ func GetServiceBindingEnvsForMysql(mysql DatabaseMySql) ([]Env, error) {
 			{
 				Name:  "spring.datasource.username",
 				Value: ToServiceBindingEnvValue(ServiceTypeDbMySQL, ServiceBindingInfoTypeUsername),
+			},
+			{
+				Name:  "spring.datasource.password",
+				Value: "",
 			},
 			{
 				Name:  "spring.datasource.azure.passwordless-enabled",


### PR DESCRIPTION
when MI auth enabled (passwordless-enabled = true), we still need to manually set the password as empty. Otherwise, if source code set password, Jdbc will use password auth instead of MI auth.