### PR TITLE
Fix: convert sub-module relative path into unix format when pack build

### DIFF
--- a/cli/azd/pkg/project/framework_service_docker.go
+++ b/cli/azd/pkg/project/framework_service_docker.go
@@ -469,7 +469,7 @@ func (p *dockerProject) packBuild(
 				if err != nil {
 					return nil, err
 				}
-				environ = append(environ, fmt.Sprintf("BP_MAVEN_BUILT_MODULE=%s", svcRelPath))
+				environ = append(environ, fmt.Sprintf("BP_MAVEN_BUILT_MODULE=%s", filepath.ToSlash(svcRelPath)))
 			}
 		}
 


### PR DESCRIPTION
In a multi-module project, when the relative path of a sub-module contains `\`, it won't be identified by pack build, we need to convert the file path to unix format, not windows format.

For example, the relative path may be `eventhubs\spring-cloud-azure-starter\spring-cloud-azure-sample-eventhubs-kafka` in windows, we need to feed it as `eventhubs/spring-cloud-azure-starter/spring-cloud-azure-sample-eventhubs-kafka` into pack build.