### PR TITLE
When placeholder not detected in application.yml, prompt user to input

### DIFF
--- a/cli/azd/internal/appdetect/appdetect.go
+++ b/cli/azd/internal/appdetect/appdetect.go
@@ -173,6 +173,8 @@ func (a AzureDepStorageAccount) ResourceDisplay() string {
 type Metadata struct {
 	ApplicationName                                         string
 	DatabaseNameInPropertySpringDatasourceUrl               map[DatabaseDep]string
+	BindingDestinationInProperty                            map[string]string
+	EventhubCheckpointStoreContainer                        map[string]string
 	ContainsDependencySpringCloudAzureStarter               bool
 	ContainsDependencySpringCloudAzureStarterJdbcPostgresql bool
 	ContainsDependencySpringCloudAzureStarterJdbcMysql      bool

--- a/cli/azd/internal/appdetect/appdetect.go
+++ b/cli/azd/internal/appdetect/appdetect.go
@@ -174,7 +174,7 @@ type Metadata struct {
 	ApplicationName                                         string
 	DatabaseNameInPropertySpringDatasourceUrl               map[DatabaseDep]string
 	BindingDestinationInProperty                            map[string]string
-	EventhubCheckpointStoreContainer                        map[string]string
+	EventhubsCheckpointStoreContainer                       map[string]string
 	ContainsDependencySpringCloudAzureStarter               bool
 	ContainsDependencySpringCloudAzureStarterJdbcPostgresql bool
 	ContainsDependencySpringCloudAzureStarterJdbcMysql      bool

--- a/cli/azd/internal/appdetect/spring_boot.go
+++ b/cli/azd/internal/appdetect/spring_boot.go
@@ -265,7 +265,7 @@ func detectMetadata(azdProject *Project, springBootProject *SpringBootProject) {
 	detectPropertySpringDataMongodbUri(azdProject, springBootProject)
 	detectPropertySpringDatasourceUrl(azdProject, springBootProject)
 	detectPropertySpringCloudStreamBindingDestination(azdProject, springBootProject)
-	detectPropertyEventhubCheckpointStoreContainer(azdProject, springBootProject)
+	detectPropertyEventhubsCheckpointStoreContainer(azdProject, springBootProject)
 
 	detectDependencySpringCloudAzureStarter(azdProject, springBootProject)
 	detectDependencySpringCloudAzureStarterJdbcMysql(azdProject, springBootProject)
@@ -388,14 +388,14 @@ func detectPropertySpringCloudStreamBindingDestination(azdProject *Project, spri
 	}
 }
 
-func detectPropertyEventhubCheckpointStoreContainer(azdProject *Project, springBootProject *SpringBootProject) {
+func detectPropertyEventhubsCheckpointStoreContainer(azdProject *Project, springBootProject *SpringBootProject) {
 	result := make(map[string]string)
 	for key, value := range springBootProject.applicationProperties {
 		if strings.HasSuffix(key, "spring.cloud.azure.eventhubs.processor.checkpoint-store.container-name") {
 			result[key] = value
 		}
 	}
-	azdProject.Metadata.EventhubCheckpointStoreContainer = result
+	azdProject.Metadata.EventhubsCheckpointStoreContainer = result
 }
 
 func detectDependencySpringCloudAzureStarter(azdProject *Project, springBootProject *SpringBootProject) {

--- a/cli/azd/internal/appdetect/spring_boot.go
+++ b/cli/azd/internal/appdetect/spring_boot.go
@@ -165,7 +165,7 @@ func detectServiceBusAccordingToSpringCloudStreamBinderMavenDependency(
 	var targetArtifactId = "spring-cloud-azure-stream-binder-servicebus"
 	if hasDependency(springBootProject, targetGroupId, targetArtifactId) {
 		bindingDestinations := getBindingDestinationMap(springBootProject.applicationProperties)
-		var destinations = DistinctValues(bindingDestinations)
+		var destinations = distinctValues(bindingDestinations)
 		newDep := AzureDepServiceBus{
 			Queues: destinations,
 			IsJms:  false,
@@ -191,7 +191,7 @@ func detectEventHubsAccordingToSpringCloudStreamBinderMavenDependency(
 	var targetArtifactId = "spring-cloud-azure-stream-binder-eventhubs"
 	if hasDependency(springBootProject, targetGroupId, targetArtifactId) {
 		bindingDestinations := getBindingDestinationMap(springBootProject.applicationProperties)
-		var destinations = DistinctValues(bindingDestinations)
+		var destinations = distinctValues(bindingDestinations)
 		newDep := AzureDepEventHubs{
 			Names:    destinations,
 			UseKafka: false,
@@ -211,7 +211,7 @@ func detectEventHubsAccordingToSpringCloudStreamKafkaMavenDependency(
 	var targetArtifactId = "spring-cloud-starter-stream-kafka"
 	if hasDependency(springBootProject, targetGroupId, targetArtifactId) {
 		bindingDestinations := getBindingDestinationMap(springBootProject.applicationProperties)
-		var destinations = DistinctValues(bindingDestinations)
+		var destinations = distinctValues(bindingDestinations)
 		newDep := AzureDepEventHubs{
 			Names:             destinations,
 			UseKafka:          true,
@@ -543,7 +543,7 @@ func isSpringBootApplication(mavenProject *mavenProject) bool {
 	return false
 }
 
-func DistinctValues(input map[string]string) []string {
+func distinctValues(input map[string]string) []string {
 	valueSet := make(map[string]struct{})
 	for _, value := range input {
 		valueSet[value] = struct{}{}

--- a/cli/azd/internal/appdetect/spring_boot.go
+++ b/cli/azd/internal/appdetect/spring_boot.go
@@ -395,7 +395,9 @@ func detectPropertyEventhubsCheckpointStoreContainer(azdProject *Project, spring
 			result[key] = value
 		}
 	}
-	azdProject.Metadata.EventhubsCheckpointStoreContainer = result
+	if len(result) != 0 {
+		azdProject.Metadata.BindingDestinationInProperty = result
+	}
 }
 
 func detectDependencySpringCloudAzureStarter(azdProject *Project, springBootProject *SpringBootProject) {

--- a/cli/azd/internal/appdetect/spring_boot.go
+++ b/cli/azd/internal/appdetect/spring_boot.go
@@ -247,11 +247,11 @@ func detectStorageAccountAccordingToSpringCloudStreamBinderMavenDependencyAndPro
 		if containsInBindingName != "" {
 			// get distinct container names
 			var containerNames []string
-			seen := make(map[string]string)
+			seen := make(map[string]struct{})
 			for key, value := range springBootProject.applicationProperties {
 				if strings.HasSuffix(key, targetPropertyName) {
 					if _, exists := seen[key]; !exists {
-						seen[key] = value
+						seen[key] = struct{}{}
 						containerNames = append(containerNames, value)
 					}
 				}

--- a/cli/azd/internal/repository/app_init.go
+++ b/cli/azd/internal/repository/app_init.go
@@ -7,7 +7,6 @@ import (
 	"maps"
 	"os"
 	"path/filepath"
-	"regexp"
 	"slices"
 	"strings"
 	"time"
@@ -156,31 +155,24 @@ func (i *Initializer) InitFromApp(
 					}
 				}
 				if eventHubs, ok := dep.(appdetect.AzureDepEventHubs); ok && !eventHubs.UseKafka {
-					for bindingName, destination := range prj.Metadata.BindingDestinationInProperty {
+					for key, destination := range prj.Metadata.BindingDestinationInProperty {
 						if destination == "" {
-							destinationInput, err := promptBindingDestination(i.console, ctx, bindingName)
+							err := promptMissingPropertyAndExit(i.console, ctx, key)
 							if err != nil {
 								return err
 							}
-							prj.Metadata.BindingDestinationInProperty[bindingName] = destinationInput
 						}
 					}
-					eventHubs.Names = appdetect.DistinctValues(prj.Metadata.BindingDestinationInProperty)
-					prj.AzureDeps[depIndex] = eventHubs
 				}
-				if storageAccount, ok := dep.(appdetect.AzureDepStorageAccount); ok {
+				if _, ok := dep.(appdetect.AzureDepStorageAccount); ok {
 					for key, containerName := range prj.Metadata.EventhubsCheckpointStoreContainer {
 						if containerName == "" {
-							containerNameInput, err := promptStorageContainerName(i.console, ctx, key)
+							err := promptMissingPropertyAndExit(i.console, ctx, key)
 							if err != nil {
 								return err
 							}
-							prj.Metadata.EventhubsCheckpointStoreContainer[key] = containerNameInput
 						}
 					}
-					storageAccount.ContainerNames =
-						appdetect.DistinctValues(prj.Metadata.EventhubsCheckpointStoreContainer)
-					prj.AzureDeps[depIndex] = storageAccount
 				}
 			}
 
@@ -1109,61 +1101,10 @@ func promptSpringBootVersion(console input.Console, ctx context.Context) (string
 	}
 }
 
-func promptBindingDestination(console input.Console, ctx context.Context, bindingName string) (string, error) {
-	for {
-		destination, err := console.Prompt(ctx, input.ConsoleOptions{
-			Message: fmt.Sprintf("Input the value for spring.cloud.stream.bindings.%s.destination", bindingName),
-			Help: fmt.Sprintf("Hint: Azure Eventhubs Name, please also ensure that the value of property "+
-				"spring.cloud.stream.bindings.%s.destination is configured as your input.", bindingName),
-		})
-		if err != nil {
-			return "", err
-		}
-		if IsValidEventhubsName(destination) {
-			return destination, nil
-		} else {
-			console.Message(ctx, "Invalid destination. Please choose another name.")
-		}
-	}
-}
-
-// contain letters, numbers, periods (.), hyphens (-), and underscores (_)
-// must begin and end with a letter or number
-var eventHubsNameRegex = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._-]*[a-zA-Z0-9]$`)
-
-func IsValidEventhubsName(name string) bool {
-	// up to 256 characters
-	if len(name) == 0 || len(name) > 256 {
-		return false
-	}
-	return eventHubsNameRegex.MatchString(name)
-}
-
-func promptStorageContainerName(console input.Console, ctx context.Context, key string) (string, error) {
-	for {
-		containerName, err := console.Prompt(ctx, input.ConsoleOptions{
-			Message: fmt.Sprintf("Input the value for %s", key),
-			Help: fmt.Sprintf("Hint: Azure Storage Container Name, "+
-				"please also ensure that the value of property %s is configured as your input.", key),
-		})
-		if err != nil {
-			return "", err
-		}
-		if IsValidContainerName(containerName) {
-			return containerName, nil
-		} else {
-			console.Message(ctx, "Invalid container name. Please choose another name.")
-		}
-	}
-}
-
-var storageContainerNameRegex = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]*[a-z0-9])?$`)
-
-func IsValidContainerName(name string) bool {
-	if len(name) < 3 || len(name) > 63 {
-		return false
-	}
-	return storageContainerNameRegex.MatchString(name)
+func promptMissingPropertyAndExit(console input.Console, ctx context.Context, key string) error {
+	console.Message(ctx, fmt.Sprintf("No value was provided for %s. Please update the 'application.properties' "+
+		"file with a valid value.", key))
+	return fmt.Errorf("missing configuration: %s", key)
 }
 
 func appendJavaEurekaServerEnv(svc *project.ServiceConfig, eurekaServerName string) error {

--- a/cli/azd/internal/repository/app_init.go
+++ b/cli/azd/internal/repository/app_init.go
@@ -169,17 +169,17 @@ func (i *Initializer) InitFromApp(
 					prj.AzureDeps[depIndex] = eventHubs
 				}
 				if storageAccount, ok := dep.(appdetect.AzureDepStorageAccount); ok {
-					for key, containerName := range prj.Metadata.EventhubCheckpointStoreContainer {
+					for key, containerName := range prj.Metadata.EventhubsCheckpointStoreContainer {
 						if containerName == "" {
 							containerNameInput, err := promptStorageContainerName(i.console, ctx, key)
 							if err != nil {
 								return err
 							}
-							prj.Metadata.EventhubCheckpointStoreContainer[key] = containerNameInput
+							prj.Metadata.EventhubsCheckpointStoreContainer[key] = containerNameInput
 						}
 					}
 					storageAccount.ContainerNames =
-						appdetect.DistinctValues(prj.Metadata.EventhubCheckpointStoreContainer)
+						appdetect.DistinctValues(prj.Metadata.EventhubsCheckpointStoreContainer)
 					prj.AzureDeps[depIndex] = storageAccount
 				}
 			}
@@ -1113,12 +1113,12 @@ func promptBindingDestination(console input.Console, ctx context.Context, bindin
 	for {
 		destination, err := console.Prompt(ctx, input.ConsoleOptions{
 			Message: fmt.Sprintf("Input the value for spring.cloud.stream.bindings.%s.destination", bindingName),
-			Help:    "Hint: Azure Eventhub Name, please also ensure application properties is well configured.",
+			Help:    "Hint: Azure Eventhubs Name, please also ensure application properties is well configured.",
 		})
 		if err != nil {
 			return "", err
 		}
-		if IsValidEventhubName(destination) {
+		if IsValidEventhubsName(destination) {
 			return destination, nil
 		} else {
 			console.Message(ctx, "Invalid destination. Please choose another name.")
@@ -1126,7 +1126,7 @@ func promptBindingDestination(console input.Console, ctx context.Context, bindin
 	}
 }
 
-func IsValidEventhubName(name string) bool {
+func IsValidEventhubsName(name string) bool {
 	// up to 256 characters
 	if len(name) == 0 || len(name) > 256 {
 		return false

--- a/cli/azd/internal/repository/app_init.go
+++ b/cli/azd/internal/repository/app_init.go
@@ -1126,15 +1126,16 @@ func promptBindingDestination(console input.Console, ctx context.Context, bindin
 	}
 }
 
+// contain letters, numbers, periods (.), hyphens (-), and underscores (_)
+// must begin and end with a letter or number
+var eventHubsNameRegex = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._-]*[a-zA-Z0-9]$`)
+
 func IsValidEventhubsName(name string) bool {
 	// up to 256 characters
 	if len(name) == 0 || len(name) > 256 {
 		return false
 	}
-	// contain letters, numbers, periods (.), hyphens (-), and underscores (_)
-	// must begin and end with a letter or number
-	regex := regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._-]*[a-zA-Z0-9]$`)
-	return regex.MatchString(name)
+	return eventHubsNameRegex.MatchString(name)
 }
 
 func promptStorageContainerName(console input.Console, ctx context.Context, key string) (string, error) {
@@ -1154,12 +1155,13 @@ func promptStorageContainerName(console input.Console, ctx context.Context, key 
 	}
 }
 
+var storageContainerNameRegex = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]*[a-z0-9])?$`)
+
 func IsValidContainerName(name string) bool {
 	if len(name) < 3 || len(name) > 63 {
 		return false
 	}
-	regex := regexp.MustCompile(`^[a-z0-9]([a-z0-9-]*[a-z0-9])?$`)
-	return regex.MatchString(name)
+	return storageContainerNameRegex.MatchString(name)
 }
 
 func appendJavaEurekaServerEnv(svc *project.ServiceConfig, eurekaServerName string) error {

--- a/cli/azd/internal/repository/app_init.go
+++ b/cli/azd/internal/repository/app_init.go
@@ -1113,7 +1113,8 @@ func promptBindingDestination(console input.Console, ctx context.Context, bindin
 	for {
 		destination, err := console.Prompt(ctx, input.ConsoleOptions{
 			Message: fmt.Sprintf("Input the value for spring.cloud.stream.bindings.%s.destination", bindingName),
-			Help:    "Hint: Azure Eventhubs Name, please also ensure application properties is well configured.",
+			Help: fmt.Sprintf("Hint: Azure Eventhubs Name, please also ensure that the value of property "+
+				"spring.cloud.stream.bindings.%s.destination is configured as your input.", bindingName),
 		})
 		if err != nil {
 			return "", err
@@ -1142,7 +1143,8 @@ func promptStorageContainerName(console input.Console, ctx context.Context, key 
 	for {
 		containerName, err := console.Prompt(ctx, input.ConsoleOptions{
 			Message: fmt.Sprintf("Input the value for %s", key),
-			Help:    "Hint: Azure Storage Container Name, please also ensure application properties is well configured.",
+			Help: fmt.Sprintf("Hint: Azure Storage Container Name, "+
+				"please also ensure that the value of property %s is configured as your input.", key),
 		})
 		if err != nil {
 			return "", err

--- a/cli/azd/internal/repository/app_init.go
+++ b/cli/azd/internal/repository/app_init.go
@@ -2,7 +2,6 @@ package repository
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"maps"
 	"os"
@@ -157,20 +156,14 @@ func (i *Initializer) InitFromApp(
 				if eventHubs, ok := dep.(appdetect.AzureDepEventHubs); ok && !eventHubs.UseKafka {
 					for key, destination := range prj.Metadata.BindingDestinationInProperty {
 						if destination == "" {
-							err := promptMissingPropertyAndExit(i.console, ctx, key)
-							if err != nil {
-								return err
-							}
+							promptMissingPropertyAndExit(i.console, ctx, key)
 						}
 					}
 				}
 				if _, ok := dep.(appdetect.AzureDepStorageAccount); ok {
 					for key, containerName := range prj.Metadata.EventhubsCheckpointStoreContainer {
 						if containerName == "" {
-							err := promptMissingPropertyAndExit(i.console, ctx, key)
-							if err != nil {
-								return err
-							}
+							promptMissingPropertyAndExit(i.console, ctx, key)
 						}
 					}
 				}
@@ -1060,9 +1053,10 @@ func processSpringCloudAzureDepByPrompt(console input.Console, ctx context.Conte
 
 	switch continueOption {
 	case 0:
-		return errors.New("you have to manually add dependency com.azure.spring:spring-cloud-azure-starter. " +
-			"And use right version according to this page: " +
+		console.Message(ctx, "you have to manually add dependency com.azure.spring:spring-cloud-azure-starter. "+
+			"And use right version according to this page: "+
 			"https://github.com/Azure/azure-sdk-for-java/wiki/Spring-Versions-Mapping")
+		os.Exit(0)
 	case 1:
 		return nil
 	case 2:
@@ -1101,10 +1095,10 @@ func promptSpringBootVersion(console input.Console, ctx context.Context) (string
 	}
 }
 
-func promptMissingPropertyAndExit(console input.Console, ctx context.Context, key string) error {
-	console.Message(ctx, fmt.Sprintf("No value was provided for %s. Please update the 'application.properties' "+
-		"file with a valid value.", key))
-	return fmt.Errorf("missing configuration: %s", key)
+func promptMissingPropertyAndExit(console input.Console, ctx context.Context, key string) {
+	console.Message(ctx, fmt.Sprintf("No value was provided for %s. Please update the configuration file "+
+		"(like application.properties or application.yaml) with a valid value.", key))
+	os.Exit(0)
 }
 
 func appendJavaEurekaServerEnv(svc *project.ServiceConfig, eurekaServerName string) error {


### PR DESCRIPTION
Before in the sample application, we use explicit variables in the application.yml.

When placeholder not detected in application.yml, prompt user to input.

To fix these samples:
- [single-binder](https://github.com/azure-javaee/azure-spring-boot-samples/tree/main/eventhubs/spring-cloud-azure-stream-binder-eventhubs/eventhubs-binder)
- multi-binders:
  - [spring2 sample](https://github.com/azure-javaee/azure-spring-boot-samples/tree/main/eventhubs/spring-cloud-azure-stream-binder-eventhubs/eventhubs-multibinders/spring2sample)
  - [spring3 sample](https://github.com/azure-javaee/azure-spring-boot-samples/tree/main/eventhubs/spring-cloud-azure-stream-binder-eventhubs/eventhubs-multibinders/spring3sample)
