### PR TITLE
Enhancement: support to resolve placeholder for Kafka and detect eventhubs starter dependency

### DIFF
--- a/cli/azd/internal/appdetect/appdetect.go
+++ b/cli/azd/internal/appdetect/appdetect.go
@@ -173,6 +173,8 @@ func (a AzureDepStorageAccount) ResourceDisplay() string {
 type Metadata struct {
 	ApplicationName                                         string
 	DatabaseNameInPropertySpringDatasourceUrl               map[DatabaseDep]string
+	BindingDestinationInProperty                            map[string]string
+	EventhubCheckpointStoreContainer                        map[string]string
 	ContainsDependencySpringCloudAzureStarter               bool
 	ContainsDependencySpringCloudAzureStarterJdbcPostgresql bool
 	ContainsDependencySpringCloudAzureStarterJdbcMysql      bool

--- a/cli/azd/internal/appdetect/appdetect.go
+++ b/cli/azd/internal/appdetect/appdetect.go
@@ -158,14 +158,6 @@ type AzureDepEventHubs struct {
 	SpringBootVersion        string
 }
 
-type EventHubsDependency string
-
-const (
-	SpringCloudAzureStreamEventHubsBinder EventHubsDependency = "SpringCloudAzureStreamEventHubsBinder"
-	SpringCloudAzureEventHubsStarter      EventHubsDependency = "SpringCloudAzureEventHubsStarter"
-	SpringCloudStarterStreamKafka         EventHubsDependency = "SpringCloudStarterStreamKafka"
-)
-
 func (a AzureDepEventHubs) ResourceDisplay() string {
 	return "Azure Event Hubs"
 }

--- a/cli/azd/internal/appdetect/appdetect.go
+++ b/cli/azd/internal/appdetect/appdetect.go
@@ -156,7 +156,16 @@ type AzureDepEventHubs struct {
 	Names             []string
 	UseKafka          bool
 	SpringBootVersion string
+	DepFrom           EventHubsDependency
 }
+
+type EventHubsDependency string
+
+const (
+	SpringCloudAzureStreamEventHubsBinder EventHubsDependency = "SpringCloudAzureStreamEventHubsBinder"
+	SpringCloudAzureEventHubsStarter      EventHubsDependency = "SpringCloudAzureEventHubsStarter"
+	SpringCloudStarterStreamKafka         EventHubsDependency = "SpringCloudStarterStreamKafka"
+)
 
 func (a AzureDepEventHubs) ResourceDisplay() string {
 	return "Azure Event Hubs"
@@ -175,6 +184,7 @@ type Metadata struct {
 	DatabaseNameInPropertySpringDatasourceUrl               map[DatabaseDep]string
 	BindingDestinationInProperty                            map[string]string
 	EventhubsCheckpointStoreContainer                       map[string]string
+	EventhubsNameInProperty                                 string
 	ContainsDependencySpringCloudAzureStarter               bool
 	ContainsDependencySpringCloudAzureStarterJdbcPostgresql bool
 	ContainsDependencySpringCloudAzureStarterJdbcMysql      bool

--- a/cli/azd/internal/appdetect/appdetect.go
+++ b/cli/azd/internal/appdetect/appdetect.go
@@ -153,10 +153,9 @@ func (a AzureDepServiceBus) ResourceDisplay() string {
 }
 
 type AzureDepEventHubs struct {
-	Names             []string
-	UseKafka          bool
-	SpringBootVersion string
-	DepFrom           EventHubsDependency
+	EventHubsNamePropertyMap map[string]string
+	UseKafka                 bool
+	SpringBootVersion        string
 }
 
 type EventHubsDependency string
@@ -172,7 +171,7 @@ func (a AzureDepEventHubs) ResourceDisplay() string {
 }
 
 type AzureDepStorageAccount struct {
-	ContainerNames []string
+	ContainerNamePropertyMap map[string]string
 }
 
 func (a AzureDepStorageAccount) ResourceDisplay() string {
@@ -182,9 +181,6 @@ func (a AzureDepStorageAccount) ResourceDisplay() string {
 type Metadata struct {
 	ApplicationName                                         string
 	DatabaseNameInPropertySpringDatasourceUrl               map[DatabaseDep]string
-	BindingDestinationInProperty                            map[string]string
-	EventhubsCheckpointStoreContainer                       map[string]string
-	EventhubsNameInProperty                                 map[string]string
 	ContainsDependencySpringCloudAzureStarter               bool
 	ContainsDependencySpringCloudAzureStarterJdbcPostgresql bool
 	ContainsDependencySpringCloudAzureStarterJdbcMysql      bool

--- a/cli/azd/internal/appdetect/appdetect.go
+++ b/cli/azd/internal/appdetect/appdetect.go
@@ -174,7 +174,7 @@ type Metadata struct {
 	ApplicationName                                         string
 	DatabaseNameInPropertySpringDatasourceUrl               map[DatabaseDep]string
 	BindingDestinationInProperty                            map[string]string
-	EventhubCheckpointStoreContainer                        map[string]string
+	EventhubsCheckpointStoreContainer                       map[string]string
 	ContainsDependencySpringCloudAzureStarter               bool
 	ContainsDependencySpringCloudAzureStarterJdbcPostgresql bool
 	ContainsDependencySpringCloudAzureStarterJdbcMysql      bool

--- a/cli/azd/internal/appdetect/appdetect.go
+++ b/cli/azd/internal/appdetect/appdetect.go
@@ -184,7 +184,7 @@ type Metadata struct {
 	DatabaseNameInPropertySpringDatasourceUrl               map[DatabaseDep]string
 	BindingDestinationInProperty                            map[string]string
 	EventhubsCheckpointStoreContainer                       map[string]string
-	EventhubsNameInProperty                                 string
+	EventhubsNameInProperty                                 map[string]string
 	ContainsDependencySpringCloudAzureStarter               bool
 	ContainsDependencySpringCloudAzureStarterJdbcPostgresql bool
 	ContainsDependencySpringCloudAzureStarterJdbcMysql      bool

--- a/cli/azd/internal/appdetect/spring_boot.go
+++ b/cli/azd/internal/appdetect/spring_boot.go
@@ -265,7 +265,7 @@ func detectMetadata(azdProject *Project, springBootProject *SpringBootProject) {
 	detectPropertySpringDataMongodbUri(azdProject, springBootProject)
 	detectPropertySpringDatasourceUrl(azdProject, springBootProject)
 	detectPropertySpringCloudStreamBindingDestination(azdProject, springBootProject)
-	detectPropertyEventhubCheckpointStoreContainer(azdProject, springBootProject)
+	detectPropertyEventhubsCheckpointStoreContainer(azdProject, springBootProject)
 
 	detectDependencySpringCloudAzureStarter(azdProject, springBootProject)
 	detectDependencySpringCloudAzureStarterJdbcMysql(azdProject, springBootProject)
@@ -388,14 +388,14 @@ func detectPropertySpringCloudStreamBindingDestination(azdProject *Project, spri
 	}
 }
 
-func detectPropertyEventhubCheckpointStoreContainer(azdProject *Project, springBootProject *SpringBootProject) {
+func detectPropertyEventhubsCheckpointStoreContainer(azdProject *Project, springBootProject *SpringBootProject) {
 	result := make(map[string]string)
 	for key, value := range springBootProject.applicationProperties {
 		if strings.HasSuffix(key, "spring.cloud.azure.eventhubs.processor.checkpoint-store.container-name") {
 			result[key] = value
 		}
 	}
-	azdProject.Metadata.EventhubCheckpointStoreContainer = result
+	azdProject.Metadata.EventhubsCheckpointStoreContainer = result
 }
 
 func detectDependencySpringCloudAzureStarter(azdProject *Project, springBootProject *SpringBootProject) {

--- a/cli/azd/internal/appdetect/spring_boot.go
+++ b/cli/azd/internal/appdetect/spring_boot.go
@@ -432,7 +432,7 @@ func detectPropertySpringCloudAzureEventhubsName(azdProject *Project, springBoot
 		log.Printf("%s property not exist in project. Path = %s", targetPropertyName, azdProject.Path)
 		return
 	}
-	azdProject.Metadata.EventhubsNameInProperty = propertyValue
+	azdProject.Metadata.EventhubsNameInProperty[targetPropertyName] = propertyValue
 }
 
 func detectDependencySpringCloudAzureStarter(azdProject *Project, springBootProject *SpringBootProject) {

--- a/cli/azd/internal/appdetect/spring_boot.go
+++ b/cli/azd/internal/appdetect/spring_boot.go
@@ -521,7 +521,9 @@ func detectSpringBootVersionFromProject(project *mavenProject) string {
 func isSpringBootApplication(mavenProject *mavenProject) bool {
 	// how can we tell it's a Spring Boot project?
 	// 1. It has a parent with a groupId of org.springframework.boot and an artifactId of spring-boot-starter-parent
-	// 2. It has a dependency with a groupId of org.springframework.boot and an artifactId that starts with
+	// 2. It has a dependency management with a groupId of org.springframework.boot and an artifactId of
+	// spring-boot-dependencies
+	// 3. It has a dependency with a groupId of org.springframework.boot and an artifactId that starts with
 	// spring-boot-starter
 	if mavenProject.Parent.GroupId == "org.springframework.boot" &&
 		mavenProject.Parent.ArtifactId == "spring-boot-starter-parent" {

--- a/cli/azd/internal/appdetect/spring_boot.go
+++ b/cli/azd/internal/appdetect/spring_boot.go
@@ -395,7 +395,9 @@ func detectPropertyEventhubsCheckpointStoreContainer(azdProject *Project, spring
 			result[key] = value
 		}
 	}
-	azdProject.Metadata.EventhubsCheckpointStoreContainer = result
+	if len(result) != 0 {
+		azdProject.Metadata.BindingDestinationInProperty = result
+	}
 }
 
 func detectDependencySpringCloudAzureStarter(azdProject *Project, springBootProject *SpringBootProject) {

--- a/cli/azd/internal/appdetect/spring_boot.go
+++ b/cli/azd/internal/appdetect/spring_boot.go
@@ -556,6 +556,12 @@ func isSpringBootApplication(mavenProject *mavenProject) bool {
 		mavenProject.Parent.ArtifactId == "spring-boot-starter-parent" {
 		return true
 	}
+	for _, dep := range mavenProject.DependencyManagement.Dependencies {
+		if dep.GroupId == "org.springframework.boot" &&
+			dep.ArtifactId == "spring-boot-dependencies" {
+			return true
+		}
+	}
 	for _, dep := range mavenProject.Dependencies {
 		if dep.GroupId == "org.springframework.boot" &&
 			strings.HasPrefix(dep.ArtifactId, "spring-boot-starter") {

--- a/cli/azd/internal/repository/app_init.go
+++ b/cli/azd/internal/repository/app_init.go
@@ -173,10 +173,10 @@ func (i *Initializer) InitFromApp(
 							if err != nil {
 								return err
 							}
-							prj.Metadata.EventhubsNameInProperty = eventHubsName
-						}
-						eventHubs.Names = []string{
-							prj.Metadata.EventhubsNameInProperty,
+							projects[index].Metadata.EventhubsNameInProperty = eventHubsName
+							eventHubs.Names = []string{
+								eventHubsName,
+							}
 						}
 					}
 					prj.AzureDeps[depIndex] = eventHubs

--- a/cli/azd/internal/repository/app_init.go
+++ b/cli/azd/internal/repository/app_init.go
@@ -169,17 +169,17 @@ func (i *Initializer) InitFromApp(
 					prj.AzureDeps[depIndex] = eventHubs
 				}
 				if storageAccount, ok := dep.(appdetect.AzureDepStorageAccount); ok {
-					for key, containerName := range prj.Metadata.EventhubCheckpointStoreContainer {
+					for key, containerName := range prj.Metadata.EventhubsCheckpointStoreContainer {
 						if containerName == "" {
 							containerNameInput, err := promptStorageContainerName(i.console, ctx, key)
 							if err != nil {
 								return err
 							}
-							prj.Metadata.EventhubCheckpointStoreContainer[key] = containerNameInput
+							prj.Metadata.EventhubsCheckpointStoreContainer[key] = containerNameInput
 						}
 					}
 					storageAccount.ContainerNames =
-						appdetect.DistinctValues(prj.Metadata.EventhubCheckpointStoreContainer)
+						appdetect.DistinctValues(prj.Metadata.EventhubsCheckpointStoreContainer)
 					prj.AzureDeps[depIndex] = storageAccount
 				}
 			}
@@ -1113,12 +1113,12 @@ func promptBindingDestination(console input.Console, ctx context.Context, bindin
 	for {
 		destination, err := console.Prompt(ctx, input.ConsoleOptions{
 			Message: fmt.Sprintf("Input the value for spring.cloud.stream.bindings.%s.destination", bindingName),
-			Help:    "Hint: Azure Eventhub Name, please also ensure application properties is well configured.",
+			Help:    "Hint: Azure Eventhubs Name, please also ensure application properties is well configured.",
 		})
 		if err != nil {
 			return "", err
 		}
-		if IsValidEventhubName(destination) {
+		if IsValidEventhubsName(destination) {
 			return destination, nil
 		} else {
 			console.Message(ctx, "Invalid destination. Please choose another name.")
@@ -1126,7 +1126,7 @@ func promptBindingDestination(console input.Console, ctx context.Context, bindin
 	}
 }
 
-func IsValidEventhubName(name string) bool {
+func IsValidEventhubsName(name string) bool {
 	// up to 256 characters
 	if len(name) == 0 || len(name) > 256 {
 		return false

--- a/cli/azd/internal/repository/infra_confirm.go
+++ b/cli/azd/internal/repository/infra_confirm.go
@@ -350,14 +350,14 @@ func (i *Initializer) buildInfraSpecByAzureDep(
 		}
 	case appdetect.AzureDepEventHubs:
 		spec.AzureEventHubs = &scaffold.AzureDepEventHubs{
-			EventHubNames:     dependency.Names,
+			EventHubNames:     appdetect.DistinctValues(dependency.EventHubsNamePropertyMap),
 			AuthType:          authType,
 			UseKafka:          dependency.UseKafka,
 			SpringBootVersion: dependency.SpringBootVersion,
 		}
 	case appdetect.AzureDepStorageAccount:
 		spec.AzureStorageAccount = &scaffold.AzureDepStorageAccount{
-			ContainerNames: dependency.ContainerNames,
+			ContainerNames: appdetect.DistinctValues(dependency.ContainerNamePropertyMap),
 			AuthType:       authType,
 		}
 	}


### PR DESCRIPTION
1. Move `NamePropertyMap` from into AzureDeps, not Metadata.
2. Resolve the placeholder of stream-kafka sample.
3. Support to detect `spring-cloud-azure-starter-eventhubs` dependency.

To fix the samples:
1. [Kafka sample with placeholder](https://github.com/azure-javaee/azure-spring-boot-samples/tree/main/eventhubs/spring-cloud-azure-starter/spring-cloud-azure-sample-eventhubs-kafka)
2. [EventHubs starter sample](https://github.com/azure-javaee/azure-spring-boot-samples/tree/main/eventhubs/spring-cloud-azure-starter-eventhubs/eventhubs-client)