### PR TITLE
Improve the code of maven command

### DIFF
--- a/cli/azd/internal/appdetect/maven_command.go
+++ b/cli/azd/internal/appdetect/maven_command.go
@@ -12,8 +12,16 @@ import (
 	"strings"
 )
 
-func getMvnCommand(pomPath string) (string, error) {
-	mvnwCommand, err := getMvnwCommandInProject(pomPath)
+func getMvnCommand() (string, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		panic(err)
+	}
+	return getMvnCommandFromPath(cwd)
+}
+
+func getMvnCommandFromPath(path string) (string, error) {
+	mvnwCommand, err := getMvnwCommand(path)
 	if err == nil {
 		return mvnwCommand, nil
 	}
@@ -23,9 +31,16 @@ func getMvnCommand(pomPath string) (string, error) {
 	return getDownloadedMvnCommand()
 }
 
-func getMvnwCommandInProject(pomPath string) (string, error) {
+func getMvnwCommand(path string) (string, error) {
 	mvnwCommand := "mvnw"
-	dir := filepath.Dir(pomPath)
+	fileInfo, err := os.Stat(path)
+	if err != nil {
+		return "", err
+	}
+	dir := filepath.Dir(path)
+	if fileInfo.IsDir() {
+		dir = path
+	}
 	for {
 		commandPath := filepath.Join(dir, mvnwCommand)
 		if fileExists(commandPath) {

--- a/cli/azd/internal/appdetect/maven_command.go
+++ b/cli/azd/internal/appdetect/maven_command.go
@@ -41,8 +41,9 @@ func getMvnwCommandInProject(pomPath string) (string, error) {
 }
 
 const mavenVersion = "3.9.9"
+const mavenZipFileName = "apache-maven-" + mavenVersion + "-bin.zip"
 const mavenURL = "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/" +
-	mavenVersion + "/apache-maven-" + mavenVersion + "-bin.zip"
+	mavenVersion + "/" + mavenZipFileName
 
 func getDownloadedMvnCommand() (string, error) {
 	mavenCommand, err := getAzdMvnCommand(mavenVersion)
@@ -65,13 +66,12 @@ func getDownloadedMvnCommand() (string, error) {
 		}
 	}
 
-	mavenFile := fmt.Sprintf("maven-wrapper-%s-bin.zip", mavenVersion)
-	wrapperPath := filepath.Join(mavenDir, mavenFile)
-	err = downloadMaven(wrapperPath)
+	mavenZipFilePath := filepath.Join(mavenDir, mavenZipFileName)
+	err = downloadMaven(mavenZipFilePath)
 	if err != nil {
 		return "", err
 	}
-	err = unzip(wrapperPath, mavenDir)
+	err = unzip(mavenZipFilePath, mavenDir)
 	if err != nil {
 		return "", fmt.Errorf("failed to unzip maven bin.zip: %w", err)
 	}

--- a/cli/azd/internal/appdetect/maven_command.go
+++ b/cli/azd/internal/appdetect/maven_command.go
@@ -79,12 +79,11 @@ func getDownloadedMvnCommand() (string, error) {
 }
 
 func getAzdMvnDir() (string, error) {
-	azdMvnFolderName := "azd-maven"
 	userHome, err := os.UserHomeDir()
 	if err != nil {
 		return "", fmt.Errorf("unable to get user home directory: %w", err)
 	}
-	return filepath.Join(userHome, azdMvnFolderName), nil
+	return filepath.Join(userHome, ".azd", "java", "maven"), nil
 }
 
 func getAzdMvnCommand(mavenVersion string) (string, error) {

--- a/cli/azd/internal/appdetect/maven_command.go
+++ b/cli/azd/internal/appdetect/maven_command.go
@@ -75,7 +75,7 @@ func getDownloadedMvnCommand() (string, error) {
 		return "", err
 	}
 	if _, err := os.Stat(mavenDir); os.IsNotExist(err) {
-		err = os.Mkdir(mavenDir, os.ModePerm)
+		err = os.MkdirAll(mavenDir, os.ModePerm)
 		if err != nil {
 			return "", fmt.Errorf("unable to create directory: %w", err)
 		}

--- a/cli/azd/internal/appdetect/maven_command.go
+++ b/cli/azd/internal/appdetect/maven_command.go
@@ -15,7 +15,7 @@ import (
 func getMvnCommand() (string, error) {
 	cwd, err := os.Getwd()
 	if err != nil {
-		panic(err)
+		return "", fmt.Errorf("can not get working directory")
 	}
 	return getMvnCommandFromPath(cwd)
 }

--- a/cli/azd/internal/appdetect/maven_command_test.go
+++ b/cli/azd/internal/appdetect/maven_command_test.go
@@ -69,3 +69,13 @@ func TestGetDownloadedMvnCommand(t *testing.T) {
 		t.Errorf("getDownloadedMvnCommand failed")
 	}
 }
+
+func TestGetMvnCommand(t *testing.T) {
+	maven, err := getMvnCommand()
+	if err != nil {
+		t.Errorf("getMvnCommand failed, %v", err)
+	}
+	if maven == "" {
+		t.Errorf("getMvnCommand failed")
+	}
+}

--- a/cli/azd/internal/appdetect/maven_command_test.go
+++ b/cli/azd/internal/appdetect/maven_command_test.go
@@ -48,7 +48,7 @@ func TestGetMvnwCommandInProject(t *testing.T) {
 				}
 			}
 
-			result, _ := getMvnwCommandInProject(pomPath)
+			result, _ := getMvnwCommand(pomPath)
 			expectedResult := ""
 			if c.expected != "" {
 				expectedResult = filepath.Join(tempDir, c.expected)

--- a/cli/azd/internal/appdetect/pom.go
+++ b/cli/azd/internal/appdetect/pom.go
@@ -114,7 +114,7 @@ func toEffectivePom(pomPath string) (pom, error) {
 	if !commandExistsInPath("java") {
 		return pom{}, fmt.Errorf("can not get effective pom because java command not exist")
 	}
-	mvn, err := getMvnCommand(pomPath)
+	mvn, err := getMvnCommandFromPath(pomPath)
 	if err != nil {
 		return pom{}, err
 	}


### PR DESCRIPTION
1. Change the path of downloaded maven.
2. Fix error of mavenZipFileName.
3. Provide a new func: getMvnCommand, which does not need input a path.