### PR TITLE
Fix the uses Env when injecting frontend and backends.

### DIFF
--- a/cli/azd/internal/scaffold/spec_service_binding.go
+++ b/cli/azd/internal/scaffold/spec_service_binding.go
@@ -193,7 +193,7 @@ func BindToContainerApp(a *ServiceSpec, b *ServiceSpec) {
 	if b.Backend == nil {
 		b.Backend = &Backend{}
 	}
-	b.Backend.Frontends = append(b.Backend.Frontends, ServiceReference{Name: b.Name})
+	b.Backend.Frontends = append(b.Backend.Frontends, ServiceReference{Name: a.Name})
 }
 
 func GetServiceBindingEnvsForPostgres(postgres DatabasePostgres) ([]Env, error) {


### PR DESCRIPTION
When service A uses service B, azd will inject the service url to each other,
In service A, the env looks like: serviceB_BASE_URL: <service B's url>
In service B, the env looks like: serviceA_BASE_URL: <service A's url>

Now there is a bug when injecting these Envs.
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2326921