### PR TITLE
Fix: SpringFrontend not displayed in detect confirm message

### DIFF
--- a/cli/azd/internal/appdetect/appdetect.go
+++ b/cli/azd/internal/appdetect/appdetect.go
@@ -92,6 +92,8 @@ func (f Dependency) Display() string {
 		return "Vite"
 	case JsNext:
 		return "Next.js"
+	case SpringFrontend:
+		return "Spring Frontend"
 	}
 
 	return ""


### PR DESCRIPTION
Fix: Spring Frontend not displayed in detect confirm message.

The screenshot after fix:

> ![image](https://github.com/user-attachments/assets/2a0b8173-2d34-4b71-a821-e43c0ad996c6)
