### PR TITLE
Fix: Application name malformed causes `azd up` failing

### DIFF
--- a/cli/azd/internal/repository/app_init.go
+++ b/cli/azd/internal/repository/app_init.go
@@ -981,7 +981,7 @@ func ServiceFromDetect(
 	svcName string,
 	prj appdetect.Project) (project.ServiceConfig, error) {
 	svc := project.ServiceConfig{
-		Name: svcName,
+		Name: names.LabelName(svcName),
 	}
 	rel, err := filepath.Rel(root, prj.Path)
 	if err != nil {


### PR DESCRIPTION
Fix: Application name malformed causes `azd up` failing.

## 1. Problem has been fixed after this PR.
![image](https://github.com/user-attachments/assets/785d8f0a-8c13-4330-8bbf-b2cf69104766)

## 2. Before this PR, `names.LabelName()` already been used to create service name.
> ![image](https://github.com/user-attachments/assets/29baf210-afe8-4c61-94ee-6f5d0999a473)
