### PR TITLE
Skip TestCreateSimulatedEffectivePom only when java command not exist

### DIFF
--- a/.github/workflows/go-test-for-sjad-branch.yml
+++ b/.github/workflows/go-test-for-sjad-branch.yml
@@ -31,4 +31,4 @@ jobs:
       - name: Run tests
         run: |
           cd ./cli/azd
-          go test $(go list ./... | grep -v github.com/azure/azure-dev/cli/azd/test/functional) -cover
+          go test $(go list ./... | grep -v github.com/azure/azure-dev/cli/azd/test/functional) -cover -v

--- a/cli/azd/internal/appdetect/pom_test.go
+++ b/cli/azd/internal/appdetect/pom_test.go
@@ -1053,8 +1053,8 @@ func TestAbsorbBuildPlugin(t *testing.T) {
 }
 
 func TestCreateSimulatedEffectivePom(t *testing.T) {
-	if os.Getenv("GITHUB_ACTIONS") == "true" {
-		t.Skip("Skip TestCreateSimulatedEffectivePom in GitHub Actions because it will time out.")
+	if !commandExistsInPath("java") {
+		t.Skip("Skip TestCreateSimulatedEffectivePom because java command not exist.")
 	}
 	var tests = []struct {
 		name     string

--- a/cli/azd/internal/appdetect/pom_test.go
+++ b/cli/azd/internal/appdetect/pom_test.go
@@ -1054,7 +1054,7 @@ func TestAbsorbBuildPlugin(t *testing.T) {
 
 func TestCreateSimulatedEffectivePom(t *testing.T) {
 	if !commandExistsInPath("java") {
-		t.Skip("Skip TestCreateSimulatedEffectivePom because java command not exist.")
+		t.Skip("Skip TestCreateSimulatedEffectivePom because java command doesn't exist.")
 	}
 	var tests = []struct {
 		name     string

--- a/cli/azd/internal/appdetect/pom_test.go
+++ b/cli/azd/internal/appdetect/pom_test.go
@@ -1,7 +1,9 @@
 package appdetect
 
 import (
+	"log/slog"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -9,6 +11,12 @@ import (
 )
 
 func TestCreateEffectivePom(t *testing.T) {
+	if !commandExistsInPath("java") {
+		t.Skip("Skip TestCreateEffectivePom because java command doesn't exist.")
+	} else {
+		path, _ := exec.LookPath("java")
+		slog.Info("Java command found.", "path", path)
+	}
 	tests := []struct {
 		name     string
 		testPoms []testPom
@@ -1055,6 +1063,9 @@ func TestAbsorbBuildPlugin(t *testing.T) {
 func TestCreateSimulatedEffectivePom(t *testing.T) {
 	if !commandExistsInPath("java") {
 		t.Skip("Skip TestCreateSimulatedEffectivePom because java command doesn't exist.")
+	} else {
+		path, _ := exec.LookPath("java")
+		slog.Info("Java command found.", "path", path)
 	}
 	var tests = []struct {
 		name     string


### PR DESCRIPTION
 - Skip TestCreateSimulatedEffectivePom only when java command not exist.
 - Add "-v" when run "go test".