### PR TITLE
Fix the bug that app built by default Dockerfile cannot fetch Envs

### DIFF
--- a/cli/azd/pkg/project/framework_service_docker.go
+++ b/cli/azd/pkg/project/framework_service_docker.go
@@ -32,6 +32,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/docker"
+	"github.com/azure/azure-dev/cli/azd/pkg/tools/maven"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/pack"
 )
 
@@ -202,20 +203,20 @@ func (p *dockerProject) Build(
 	}
 
 	// if it's a java project without Dockerfile, we help to package jar and add a default Dockerfile for Docker build
-	//if serviceConfig.Language == ServiceLanguageJava && serviceConfig.Docker.Path == "" {
-	//	mvnCli := maven.NewCli(exec.NewCommandRunner(nil))
-	//	err := mvnCli.CleanPackage(ctx, serviceConfig.RelativePath, serviceConfig.Project.Path)
-	//	if err != nil {
-	//		return nil, err
-	//	}
-	//	defaultDockerfilePath, err := addDefaultDockerfileForJavaProject(serviceConfig.Name)
-	//	if err != nil {
-	//		return nil, err
-	//	}
-	//	serviceConfig.Docker = DockerProjectOptions{
-	//		Path: defaultDockerfilePath,
-	//	}
-	//}
+	if serviceConfig.Language == ServiceLanguageJava && serviceConfig.Docker.Path == "" {
+		mvnCli := maven.NewCli(exec.NewCommandRunner(nil))
+		err := mvnCli.CleanPackage(ctx, serviceConfig.RelativePath, serviceConfig.Project.Path)
+		if err != nil {
+			return nil, err
+		}
+		defaultDockerfilePath, err := addDefaultDockerfileForJavaProject(serviceConfig.Name)
+		if err != nil {
+			return nil, err
+		}
+		serviceConfig.Docker = DockerProjectOptions{
+			Path: defaultDockerfilePath,
+		}
+	}
 
 	dockerOptions := getDockerOptionsWithDefaults(serviceConfig.Docker)
 
@@ -638,26 +639,26 @@ func getDockerOptionsWithDefaults(options DockerProjectOptions) DockerProjectOpt
 }
 
 // todo: hardcode jdk-21 as base image here, may need more accurate java version detection.
-//const DefaultDockerfileForJavaProject = `FROM openjdk:21-jdk-slim
-//COPY ./target/*.jar /app.jar
-//ENTRYPOINT ["sh", "-c", "java -jar /app.jar"]`
-//
-//func addDefaultDockerfileForJavaProject(svcName string) (string, error) {
-//	log.Printf("Dockerfile not found for java project %s, will provide a default one", svcName)
-//	dockerfileDir, err := os.MkdirTemp("", svcName)
-//	if err != nil {
-//		return "", fmt.Errorf("error creating temp Dockerfile directory: %w", err)
-//	}
-//
-//	dockerfilePath := filepath.Join(dockerfileDir, "Dockerfile")
-//	file, err := os.Create(dockerfilePath)
-//	if err != nil {
-//		return "", fmt.Errorf("error creating Dockerfile at %s: %w", dockerfilePath, err)
-//	}
-//	defer file.Close()
-//
-//	if _, err = file.WriteString(DefaultDockerfileForJavaProject); err != nil {
-//		return "", fmt.Errorf("error writing Dockerfile at %s: %w", dockerfilePath, err)
-//	}
-//	return dockerfilePath, nil
-//}
+const DefaultDockerfileForJavaProject = `FROM openjdk:21-jdk-slim
+COPY ./target/*.jar /app.jar
+ENTRYPOINT ["java", "-jar", "/app.jar"]`
+
+func addDefaultDockerfileForJavaProject(svcName string) (string, error) {
+	log.Printf("Dockerfile not found for java project %s, will provide a default one", svcName)
+	dockerfileDir, err := os.MkdirTemp("", svcName)
+	if err != nil {
+		return "", fmt.Errorf("error creating temp Dockerfile directory: %w", err)
+	}
+
+	dockerfilePath := filepath.Join(dockerfileDir, "Dockerfile")
+	file, err := os.Create(dockerfilePath)
+	if err != nil {
+		return "", fmt.Errorf("error creating Dockerfile at %s: %w", dockerfilePath, err)
+	}
+	defer file.Close()
+
+	if _, err = file.WriteString(DefaultDockerfileForJavaProject); err != nil {
+		return "", fmt.Errorf("error writing Dockerfile at %s: %w", dockerfilePath, err)
+	}
+	return dockerfilePath, nil
+}


### PR DESCRIPTION
Fix the bug that app built by default Dockerfile cannot fetch Envs.

The root cause is that, use `sh -c` before, which make the command run in the shell context, and the Envs cannot work as expected. Now run the command directly and let Docker handle the command execution directly, ensuring the environment variables propagate correctly.

Test by running the https://github.com/azure-javaee/azure-spring-boot-samples/tree/main/postgresql/spring-cloud-azure-starter-jdbc-postgresql/spring-cloud-azure-postgresql-sample