### PR TITLE
Use docker context 

### DIFF
--- a/cli/azd/internal/appdetect/appdetect.go
+++ b/cli/azd/internal/appdetect/appdetect.go
@@ -142,7 +142,8 @@ type Project struct {
 	// Experimental: Database dependencies inferred through heuristics while scanning dependencies in the project.
 	DatabaseDeps []DatabaseDep
 
-	// The path to the root project directory.
+	// The root/workspace directory for languages that support multiple projects.
+	// This may be used for example, to configure the correct context of the build for multiple projects.
 	RootPath string
 
 	// The path to the project directory.
@@ -184,8 +185,7 @@ var allDetectors = []projectDetector{
 	// Order here determines precedence when two projects are in the same directory.
 	// This is unlikely to occur in practice, but reordering could help to break the tie in these cases.
 	&javaDetector{
-		mvnCli:                  maven.NewCli(exec.NewCommandRunner(nil)),
-		modulePathToRootProject: make(map[string]mavenProject),
+		mvnCli: maven.NewCli(exec.NewCommandRunner(nil)),
 	},
 	&dotNetAppHostDetector{
 		// TODO(ellismg): Remove ambient authority.

--- a/cli/azd/internal/appdetect/appdetect_test.go
+++ b/cli/azd/internal/appdetect/appdetect_test.go
@@ -133,7 +133,7 @@ func TestDetect(t *testing.T) {
 			"IncludeExcludeLanguages",
 			[]DetectOption{
 				WithDotNet(),
-				WithJava(),
+				WithoutJava(),
 				WithJavaScript(),
 				WithoutJavaScript(),
 			},
@@ -143,50 +143,12 @@ func TestDetect(t *testing.T) {
 					Path:          "dotnet",
 					DetectionRule: "Inferred by presence of: dotnettestapp.csproj, Program.cs",
 				},
-				{
-					Language:      Java,
-					Path:          "java",
-					DetectionRule: "Inferred by presence of: pom.xml",
-				},
-				{
-					Language:      Java,
-					Path:          "java-multimodules/application",
-					RootPath:      filepath.Join(dir, "java-multimodules"),
-					DetectionRule: "Inferred by presence of: pom.xml",
-					DatabaseDeps: []DatabaseDep{
-						DbMySql,
-						DbPostgres,
-					},
-				},
-				{
-					Language:      Java,
-					Path:          "java-multimodules/library",
-					RootPath:      filepath.Join(dir, "java-multimodules"),
-					DetectionRule: "Inferred by presence of: pom.xml",
-				},
-				{
-					Language:      Java,
-					Path:          "java-multimodules/module1",
-					RootPath:      filepath.Join(dir, "java-multimodules"),
-					DetectionRule: "Inferred by presence of: pom.xml",
-				},
-				{
-					Language:      Java,
-					Path:          "java-multimodules/module2/submodule1",
-					RootPath:      filepath.Join(dir, "java-multimodules"), // point to the root, not direct parent
-					DetectionRule: "Inferred by presence of: pom.xml",
-				},
-				{
-					Language:      Java,
-					Path:          "java-multimodules/notmodule",
-					RootPath:      "",
-					DetectionRule: "Inferred by presence of: pom.xml",
-				},
 			},
 		},
 		{
 			"ExcludeLanguages",
 			[]DetectOption{
+				WithoutJava(),
 				WithoutJavaScript(),
 				WithoutPython(),
 			},
@@ -196,51 +158,13 @@ func TestDetect(t *testing.T) {
 					Path:          "dotnet",
 					DetectionRule: "Inferred by presence of: dotnettestapp.csproj, Program.cs",
 				},
-				{
-					Language:      Java,
-					Path:          "java",
-					DetectionRule: "Inferred by presence of: pom.xml",
-				},
-				{
-					Language:      Java,
-					Path:          "java-multimodules/application",
-					RootPath:      filepath.Join(dir, "java-multimodules"),
-					DetectionRule: "Inferred by presence of: pom.xml",
-					DatabaseDeps: []DatabaseDep{
-						DbMySql,
-						DbPostgres,
-					},
-				},
-				{
-					Language:      Java,
-					Path:          "java-multimodules/library",
-					RootPath:      filepath.Join(dir, "java-multimodules"),
-					DetectionRule: "Inferred by presence of: pom.xml",
-				},
-				{
-					Language:      Java,
-					Path:          "java-multimodules/module1",
-					RootPath:      filepath.Join(dir, "java-multimodules"),
-					DetectionRule: "Inferred by presence of: pom.xml",
-				},
-				{
-					Language:      Java,
-					Path:          "java-multimodules/module2/submodule1",
-					RootPath:      filepath.Join(dir, "java-multimodules"), // point to the root, not direct parent
-					DetectionRule: "Inferred by presence of: pom.xml",
-				},
-				{
-					Language:      Java,
-					Path:          "java-multimodules/notmodule",
-					RootPath:      "",
-					DetectionRule: "Inferred by presence of: pom.xml",
-				},
 			},
 		},
 		{
 			"ExcludePatterns",
 			[]DetectOption{
 				WithExcludePatterns([]string{
+					"**/*-multi*",
 					"**/*-full",
 					"**/javascript",
 					"typescript",
@@ -255,40 +179,6 @@ func TestDetect(t *testing.T) {
 				{
 					Language:      Java,
 					Path:          "java",
-					DetectionRule: "Inferred by presence of: pom.xml",
-				},
-				{
-					Language:      Java,
-					Path:          "java-multimodules/application",
-					RootPath:      filepath.Join(dir, "java-multimodules"),
-					DetectionRule: "Inferred by presence of: pom.xml",
-					DatabaseDeps: []DatabaseDep{
-						DbMySql,
-						DbPostgres,
-					},
-				},
-				{
-					Language:      Java,
-					Path:          "java-multimodules/library",
-					RootPath:      filepath.Join(dir, "java-multimodules"),
-					DetectionRule: "Inferred by presence of: pom.xml",
-				},
-				{
-					Language:      Java,
-					Path:          "java-multimodules/module1",
-					RootPath:      filepath.Join(dir, "java-multimodules"),
-					DetectionRule: "Inferred by presence of: pom.xml",
-				},
-				{
-					Language:      Java,
-					Path:          "java-multimodules/module2/submodule1",
-					RootPath:      filepath.Join(dir, "java-multimodules"), // point to the root, not direct parent
-					DetectionRule: "Inferred by presence of: pom.xml",
-				},
-				{
-					Language:      Java,
-					Path:          "java-multimodules/notmodule",
-					RootPath:      "",
 					DetectionRule: "Inferred by presence of: pom.xml",
 				},
 				{

--- a/cli/azd/internal/cmd/add/add_configure_host.go
+++ b/cli/azd/internal/cmd/add/add_configure_host.go
@@ -294,7 +294,6 @@ func ServiceFromDetect(
 
 	svc.Host = project.ContainerAppTarget
 	svc.RelativePath = rel
-	svc.RootPath = prj.RootPath
 
 	language, supported := LanguageMap[prj.Language]
 	if !supported {
@@ -309,9 +308,16 @@ func ServiceFromDetect(
 			return svc, err
 		}
 
-		svc.Docker = project.DockerProjectOptions{
-			Path: relDocker,
+		svc.Docker.Path = relDocker
+	}
+
+	if prj.RootPath != "" {
+		relContext, err := filepath.Rel(prj.Path, prj.RootPath)
+		if err != nil {
+			return svc, err
 		}
+
+		svc.Docker.Context = relContext
 	}
 
 	if prj.HasWebUIFramework() {

--- a/cli/azd/pkg/project/framework_service_docker.go
+++ b/cli/azd/pkg/project/framework_service_docker.go
@@ -463,14 +463,21 @@ func (p *dockerProject) packBuild(
 		if svc.Language == ServiceLanguageJava {
 			environ = append(environ, "ORYX_RUNTIME_PORT=8080")
 
-			// Specify parent context and build module for multi-module project when pack build
-			if svc.RootPath != "" {
-				buildContext = svc.RootPath
+			// When docker context is set
+			if svc.Docker.Context != "" {
+				buildContext = svc.Docker.Context
+				if !filepath.IsAbs(buildContext) {
+					buildContext = filepath.Join(svc.Path(), buildContext)
+				}
+
 				svcRelPath, err := filepath.Rel(buildContext, svc.Path())
 				if err != nil {
-					return nil, err
+					return nil, fmt.Errorf("calculating relative context: %w", err)
 				}
-				environ = append(environ, fmt.Sprintf("BP_MAVEN_BUILT_MODULE=%s", filepath.ToSlash(svcRelPath)))
+
+				if svcRelPath != "." {
+					environ = append(environ, fmt.Sprintf("BP_MAVEN_BUILT_MODULE=%s", filepath.ToSlash(svcRelPath)))
+				}
 			}
 		}
 

--- a/cli/azd/pkg/project/service_config.go
+++ b/cli/azd/pkg/project/service_config.go
@@ -23,8 +23,6 @@ type ServiceConfig struct {
 	ResourceName osutil.ExpandableString `yaml:"resourceName,omitempty"`
 	// The ARM api version to use for the service. If not specified, the latest version is used.
 	ApiVersion string `yaml:"apiVersion,omitempty"`
-	// The path to the root project directory
-	RootPath string `yaml:"rootPath,omitempty"`
 	// The relative path to the project folder from the project root
 	RelativePath string `yaml:"project"`
 	// The azure hosting model to use, ex) appservice, function, containerapp

--- a/schemas/alpha/azure.yaml.json
+++ b/schemas/alpha/azure.yaml.json
@@ -107,10 +107,6 @@
                         "type": "string",
                         "title": "Path to the service source code directory"
                     },
-                    "rootPath": {
-                        "type": "string",
-                        "title": "Path to the root directory of the service"
-                    },
                     "image": {
                         "type": "string",
                         "title": "Optional. The source image to be used for the container image instead of building from source. Supports environment variable substitution.",


### PR DESCRIPTION
Building on top of #4885, this change proposes resusing `docker.context` instead of a new `rootPath` property to set the root project directory, and automatically setting the relevant module to build.

Clean up the test a little and use a more basic implementation of iterating through the root modules.